### PR TITLE
TinyCore packer script

### DIFF
--- a/appliances/tinycore-linux.gns3a
+++ b/appliances/tinycore-linux.gns3a
@@ -1,0 +1,44 @@
+{
+    "name": "Tiny Core Linux",
+    "category": "guest",
+    "description": "Core Linux is a smaller variant of Tiny Core without a graphical desktop.\n\nIt's provide a complete Linux system in few MB.",
+    "vendor_name": "Team Tiny Core",
+    "vendor_url": "http://distro.ibiblio.org/tinycorelinux",
+    "documentation_url": "http://wiki.tinycorelinux.net/",
+    "product_name": "Tiny Core Linux",
+    "product_url": "http://distro.ibiblio.org/tinycorelinux",
+    "registry_version": 1,
+    "status": "stable",
+    "maintainer": "GNS3 Team",
+    "maintainer_email": "developers@gns3.net",
+    "usage": "Login is gns3/gns3. sudo works without password",
+    "symbol": "linux_guest.svg",
+
+    "qemu": {
+        "adapter_type": "e1000",
+        "adapters": 1,
+        "ram": 96,
+        "arch": "i386",
+        "console_type": "telnet"
+    },
+
+    "images": [
+        {
+            "filename": "linux-tinycore-6.4.qcow2",
+            "version": "6.4",
+            "md5sum": "bcd99ff8b3a9e7097455dcebe66ba2dd",
+            "filesize": 23855104,
+            "download_url": "https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/",
+            "direct_download_url": "http://no.public.repository.yet/linux-tinycore-6.4.qcow2"
+        }
+    ],
+
+    "versions": [
+        {
+            "name": "6.4",
+            "images": {
+                "hda_disk_image": "linux-tinycore-6.4.qcow2"
+            }
+        }
+    ]
+}

--- a/appliances/tinycore-linux.gns3a
+++ b/appliances/tinycore-linux.gns3a
@@ -26,10 +26,18 @@
         {
             "filename": "linux-tinycore-6.4.qcow2",
             "version": "6.4",
-            "md5sum": "bcd99ff8b3a9e7097455dcebe66ba2dd",
-            "filesize": 23855104,
+            "md5sum": "786a1c2f2e9db61d0580ed58a37da5dd",
+            "filesize": 23920640,
             "download_url": "https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/",
             "direct_download_url": "http://no.public.repository.yet/linux-tinycore-6.4.qcow2"
+        },
+        {
+            "filename": "linux-tinycore-4.7.7.qcow2",
+            "version": "4.7.7",
+            "md5sum": "bb4559be28875500bba2a32d3f75f6d4",
+            "filesize": 26804224,
+            "download_url": "https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/",
+            "direct_download_url": "http://no.public.repository.yet/linux-tinycore-4.7.7.qcow2"
         }
     ],
 
@@ -38,6 +46,12 @@
             "name": "6.4",
             "images": {
                 "hda_disk_image": "linux-tinycore-6.4.qcow2"
+            }
+        },
+        {
+            "name": "4.7.7",
+            "images": {
+                "hda_disk_image": "linux-tinycore-4.7.7.qcow2"
             }
         }
     ]

--- a/packer/tinycore-linux/README.rst
+++ b/packer/tinycore-linux/README.rst
@@ -1,0 +1,15 @@
+Packer for TinyCore GNS3 appliance
+==================================
+
+For building a TinyCore V6.4 appliance run:
+
+.. code:: bash
+
+    packer build -var-file=tc-6.4.json tinycore-linux.json
+
+
+Likewise, to build a TinyCore V4.7.7 appliance run:
+
+.. code:: bash
+
+    packer build -var-file=tc-4.7.7.json tinycore-linux.json

--- a/packer/tinycore-linux/scripts/hd-install.sh
+++ b/packer/tinycore-linux/scripts/hd-install.sh
@@ -32,6 +32,6 @@ sudo chgrp staff /mnt/sda1/tce
 sudo chmod 775 /mnt/sda1/tce
 
 # base system modifications
+echo -e "\nusername 'gns3', password 'gns3'\n" >> /etc/issue
 echo 'etc/issue' >> /opt/.filetool.lst
 echo 'etc/shadow' >> /opt/.filetool.lst
-echo -e "\nusername 'gns3', password 'gns3'\n" >> /etc/issue

--- a/packer/tinycore-linux/scripts/hd-install.sh
+++ b/packer/tinycore-linux/scripts/hd-install.sh
@@ -1,0 +1,37 @@
+# Install tinycore on harddisk
+
+set -x
+
+# format harddisk
+echo -e 'n\np\n1\n\n\na\n1\nw' | sudo fdisk -H16 -S32 /dev/sda
+sudo mkfs.ext2 /dev/sda1
+
+# copy system to harddisk
+sudo mkdir /mnt/sda1
+sudo mount /dev/sda1 /mnt/sda1
+sudo mount /mnt/sr0
+sudo cp -a /mnt/sr0/boot /mnt/sda1/
+sudo umount /mnt/sr0
+
+# modify bootloader config
+sudo mv /mnt/sda1/boot/isolinux /mnt/sda1/boot/extlinux
+cd /mnt/sda1/boot/extlinux
+sudo rm boot.cat isolinux.bin
+sudo mv isolinux.cfg extlinux.conf
+sudo sed -i -e '/append / s/$/ user=gns3/' -e 's/timeout .*/timeout 30/' extlinux.conf
+cd
+
+# make disk bootable
+tce-load -wi syslinux
+sudo sh -c 'cat /usr/local/share/syslinux/mbr.bin > /dev/sda'
+sudo /usr/local/sbin/extlinux --install /mnt/sda1/boot/extlinux
+
+# create extensions directory
+sudo mkdir /mnt/sda1/tce
+sudo chgrp staff /mnt/sda1/tce
+sudo chmod 775 /mnt/sda1/tce
+
+# base system modifications
+echo 'etc/issue' >> /opt/.filetool.lst
+echo 'etc/shadow' >> /opt/.filetool.lst
+echo -e "\nusername 'gns3', password 'gns3'\n" >> /etc/issue

--- a/packer/tinycore-linux/scripts/packages.sh
+++ b/packer/tinycore-linux/scripts/packages.sh
@@ -9,8 +9,10 @@ rm -rf /usr/local/tce.installed/*
 
 # openssh (optional)
 tce-load -wi openssh
-echo '/usr/local/etc/init.d/openssh start' >> /opt/bootlocal.sh
+[ -f /usr/local/etc/ssh/ssh_config.example ] && sudo cp -a /usr/local/etc/ssh/ssh_config.example /usr/local/etc/ssh/ssh_config
+[ -f /usr/local/etc/ssh/sshd_config.example ] && sudo cp -a /usr/local/etc/ssh/sshd_config.example /usr/local/etc/ssh/sshd_config
 echo 'usr/local/etc/ssh' >> /opt/.filetool.lst
+echo '/usr/local/etc/init.d/openssh start' >> /opt/bootlocal.sh
 
 tce-load -wi ipv6-`uname -r` iptables iproute2
 tce-load -wi tcpdump

--- a/packer/tinycore-linux/scripts/packages.sh
+++ b/packer/tinycore-linux/scripts/packages.sh
@@ -1,0 +1,18 @@
+# Add extensions
+
+set -x
+
+# change tcedir to harddisk
+mv /etc/sysconfig/tcedir /etc/sysconfig/tcedir.bak
+ln -s /mnt/sda1/tce /etc/sysconfig/tcedir
+rm -rf /usr/local/tce.installed/*
+
+# openssh (optional)
+tce-load -wi openssh
+echo '/usr/local/etc/init.d/openssh start' >> /opt/bootlocal.sh
+echo 'usr/local/etc/ssh' >> /opt/.filetool.lst
+
+tce-load -wi ipv6-`uname -r` iptables iproute2
+tce-load -wi tcpdump
+tce-load -wi iperf3
+

--- a/packer/tinycore-linux/scripts/post_setup.sh
+++ b/packer/tinycore-linux/scripts/post_setup.sh
@@ -1,0 +1,9 @@
+# post-installation script
+set -x
+
+# save changes
+rm -f .ash_history
+filetool.sh -b sda1
+
+# write 0, not really necessary
+#sudo dd if=/dev/zero of=/mnt/sda1/zero ; sudo rm -f /mnt/sda1/zero

--- a/packer/tinycore-linux/scripts/serial.sh
+++ b/packer/tinycore-linux/scripts/serial.sh
@@ -1,0 +1,21 @@
+# Add serial console support
+
+set -x
+
+# Boot configuration
+# Serial interface is secondary console, the vga console remains main console
+# To change that, exchange the two 'console=' boot parameter
+sudo sed -i -e '1i serial 0 38400' -e '/append loglevel/ s/$/ console=ttyS0,38400 console=tty0/' /mnt/sda1/boot/extlinux/extlinux.conf
+
+# /etc/inittab
+sudo sed -i -e '/tty6/attyS0::respawn:/sbin/getty 38400 ttyS0 xterm' /etc/inittab
+
+# /etc/securetty
+sudo sed -i -e 's/^# *ttyS0/ttyS0/' /etc/securetty
+
+# reload initab on startup
+sudo sed -i -e '/^\/opt\/bootlocal/ i' -e '/^\/opt\/bootlocal/ i# reload inittab' -e '/^\/opt\/bootlocal/ i kill -HUP 1' -e '/^\/opt\/bootlocal/ i' /opt/bootsync.sh
+
+# add modified files to backup list
+echo 'etc/inittab' >> /opt/.filetool.lst
+echo 'etc/securetty' >> /opt/.filetool.lst

--- a/packer/tinycore-linux/scripts/serial.sh
+++ b/packer/tinycore-linux/scripts/serial.sh
@@ -5,7 +5,7 @@ set -x
 # Boot configuration
 # Serial interface is secondary console, the vga console remains main console
 # To change that, exchange the two 'console=' boot parameter
-sudo sed -i -r -e '1 i serial 0 38400' -e '/label microcore/,/append / s/(append .*)/\1 console=ttyS0,38400 console=tty0/' /mnt/sda1/boot/extlinux/extlinux.conf
+sudo sed -i -e '1 i serial 0 38400' -e '/label microcore/,/append / s/\(append .*\)/\1 console=ttyS0,38400 console=tty0/' /mnt/sda1/boot/extlinux/extlinux.conf
 
 # /etc/inittab
 sudo sed -i -e '/tty6/ a ttyS0::respawn:/sbin/getty 38400 ttyS0 xterm' /etc/inittab

--- a/packer/tinycore-linux/scripts/serial.sh
+++ b/packer/tinycore-linux/scripts/serial.sh
@@ -5,16 +5,16 @@ set -x
 # Boot configuration
 # Serial interface is secondary console, the vga console remains main console
 # To change that, exchange the two 'console=' boot parameter
-sudo sed -i -e '1i serial 0 38400' -e '/append loglevel/ s/$/ console=ttyS0,38400 console=tty0/' /mnt/sda1/boot/extlinux/extlinux.conf
+sudo sed -i -r -e '1 i serial 0 38400' -e '/label microcore/,/append / s/(append .*)/\1 console=ttyS0,38400 console=tty0/' /mnt/sda1/boot/extlinux/extlinux.conf
 
 # /etc/inittab
-sudo sed -i -e '/tty6/attyS0::respawn:/sbin/getty 38400 ttyS0 xterm' /etc/inittab
+sudo sed -i -e '/tty6/ a ttyS0::respawn:/sbin/getty 38400 ttyS0 xterm' /etc/inittab
 
 # /etc/securetty
 sudo sed -i -e 's/^# *ttyS0/ttyS0/' /etc/securetty
 
-# reload initab on startup
-sudo sed -i -e '/^\/opt\/bootlocal/ i' -e '/^\/opt\/bootlocal/ i# reload inittab' -e '/^\/opt\/bootlocal/ i kill -HUP 1' -e '/^\/opt\/bootlocal/ i' /opt/bootsync.sh
+# reload inittab on startup
+sudo sed -i -e '/^\/opt\/bootlocal/ i' -e '/^\/opt\/bootlocal/ i # reload inittab' -e '/^\/opt\/bootlocal/ i kill -HUP 1' -e '/^\/opt\/bootlocal/ i' /opt/bootsync.sh
 
 # add modified files to backup list
 echo 'etc/inittab' >> /opt/.filetool.lst

--- a/packer/tinycore-linux/tc-4.7.7.json
+++ b/packer/tinycore-linux/tc-4.7.7.json
@@ -1,0 +1,4 @@
+{
+    "tc_iso_url": "http://distro.ibiblio.org/tinycorelinux/4.x/x86/archive/4.7.7/Core-4.7.7.iso",
+    "tc_iso_checksum": "f610b20a97801c937ffb791443a32640"
+}

--- a/packer/tinycore-linux/tc-6.4.json
+++ b/packer/tinycore-linux/tc-6.4.json
@@ -1,0 +1,4 @@
+{
+    "tc_iso_url": "http://distro.ibiblio.org/tinycorelinux/6.x/x86/release/Core-6.4.iso",
+    "tc_iso_checksum": "c8e04e26de234e5528e6eac8ecb1bdda"
+}

--- a/packer/tinycore-linux/tinycore-linux.json
+++ b/packer/tinycore-linux/tinycore-linux.json
@@ -1,28 +1,31 @@
 {
-  "builders":
-    [
+    "variables": {
+        "tc_iso_url": null,
+        "tc_iso_checksum": null
+    },
+    "builders": [
         {
-          "type": "qemu",
-          "iso_url": "http://distro.ibiblio.org/tinycorelinux/6.x/x86/release/Core-6.4.iso",
-          "iso_checksum": "c8e04e26de234e5528e6eac8ecb1bdda",
-          "iso_checksum_type": "md5",
-          "shutdown_command": "sudo poweroff",
-          "format": "qcow2",
-          "headless": false,
-          "ssh_username": "gns3",
-          "ssh_password": "gns3",
-          "accelerator": "none",
-          "vm_name": "tinycore-linux",
-          "disk_interface": "ide",
-          "net_device": "e1000",
-          "disk_size": 50,
-          "boot_wait": "10s",
-          "http_directory": "http",
-          "boot_command":
-            [
+            "type": "qemu",
+            "iso_url": "{{user `tc_iso_url`}}",
+            "iso_checksum": "{{user `tc_iso_checksum`}}",
+            "iso_checksum_type": "md5",
+            "shutdown_command": "sudo poweroff",
+            "format": "qcow2",
+            "headless": false,
+            "ssh_username": "gns3",
+            "ssh_password": "gns3",
+            "accelerator": "none",
+            "vm_name": "tinycore-linux",
+            "disk_interface": "ide",
+            "disk_size": 50,
+            "net_device": "e1000",
+            "http_directory": "http",
+            "boot_wait": "10s",
+            "boot_command": [
                 "mc user=gns3<enter><wait10><wait10><wait10>",
                 "sudo passwd gns3<enter>gns3<enter>gns3<enter>",
                 "tce-load -wi openssh<enter><wait10>",
+                "cd /usr/local/etc/ssh; [ -f sshd_config.example ] && sudo cp -a sshd_config.example sshd_config; cd<enter>",
                 "sudo /usr/local/etc/init.d/openssh start<enter>"
             ]
         }

--- a/packer/tinycore-linux/tinycore-linux.json
+++ b/packer/tinycore-linux/tinycore-linux.json
@@ -1,0 +1,48 @@
+{
+  "builders":
+    [
+        {
+          "type": "qemu",
+          "iso_url": "http://distro.ibiblio.org/tinycorelinux/6.x/x86/release/Core-6.4.iso",
+          "iso_checksum": "c8e04e26de234e5528e6eac8ecb1bdda",
+          "iso_checksum_type": "md5",
+          "shutdown_command": "sudo poweroff",
+          "format": "qcow2",
+          "headless": false,
+          "ssh_username": "gns3",
+          "ssh_password": "gns3",
+          "accelerator": "none",
+          "vm_name": "tinycore-linux",
+          "disk_interface": "ide",
+          "net_device": "e1000",
+          "disk_size": 50,
+          "boot_wait": "10s",
+          "http_directory": "http",
+          "boot_command":
+            [
+                "mc user=gns3<enter><wait10><wait10><wait10>",
+                "sudo passwd gns3<enter>gns3<enter>gns3<enter>",
+                "tce-load -wi openssh<enter><wait10>",
+                "sudo /usr/local/etc/init.d/openssh start<enter>"
+            ]
+        }
+    ],
+    "provisioners": [
+        {
+            "type": "shell",
+            "script": "scripts/hd-install.sh"
+        },
+        {
+            "type": "shell",
+            "script": "scripts/serial.sh"
+        },
+        {
+            "type": "shell",
+            "script": "scripts/packages.sh"
+        },
+        {
+            "type": "shell",
+            "script": "scripts/post_setup.sh"
+        }
+    ]
+}


### PR DESCRIPTION
I named it TinyCore, but that's temporary. Maybe another name should be chosen.

Currently the packages openssh, ipv6, iptables, iproute2, tcpdump and iperf3 are added. That can easily be changed by editing packer/tinycore-linux/scripts/packages.sh .