### PR TITLE
OpenSwitch update

### DIFF
--- a/packer/tinycore-linux/scripts/hd-install-64bits.sh
+++ b/packer/tinycore-linux/scripts/hd-install-64bits.sh
@@ -21,53 +21,33 @@ sudo mv isolinux.cfg extlinux.conf
 sudo sed -i -e '/append / s/$/ user=gns3/' -e 's/timeout .*/timeout 1/' extlinux.conf
 cd
 
-# make disk bootable
 
+# install 32-bit libraries
+. /etc/init.d/tc-functions
+getMirror
+MIRROR32=`echo $MIRROR | sed 's/x86_64/x86/'`
+cd /tmp
+wget `echo $MIRROR32 | sed 's/tcz$/release\/Core-current.iso/'`
+sudo mount -o loop Core-current.iso /mnt/sr0
+zcat /mnt/sr0/boot/core.gz | sudo cpio -id "lib/l*"
+sudo ln -s /tmp/lib/ld-linux.so* /lib
+sudo umount /mnt/sr0
+rm Core-current.iso
+echo /tmp/lib >> /etc/ld.so.conf
+sudo ldconfig
+cd
+
+# install 32-bit syslinux
+wget -P /tmp $MIRROR32/syslinux.tcz
+tce-load -i /tmp/syslinux.tcz
+
+# make disk bootable
+sudo sh -c 'cat /usr/local/share/syslinux/mbr.bin > /dev/sda'
+sudo /usr/local/sbin/extlinux --install /mnt/sda1/boot/extlinux
 
 # create extensions directory
 sudo mkdir /mnt/sda1/tce
 sudo mkdir -p /mnt/sda1/tce/optional/
 sudo chgrp -R staff /mnt/sda1/tce
 sudo chmod -R 775 /mnt/sda1/tce
-
-# Make lib32 extension
-tce-load -wi squashfs-tools
-mkdir /tmp/lib32
-cd /tmp/lib32
-wget http://tinycorelinux.net/6.x/x86/release/Core-current.iso
-sudo mount -o loop Core-current.iso /mnt/fd0
-mkdir lib32
-cd lib32
-zcat /mnt/fd0/boot/core.gz | cpio -id "lib/l*" "usr/lib/l*"
-mkdir -p usr/local/lib
-cd ..
-sudo umount /mnt/fd0
-rm Core-current.iso
-mkdir lib
-ln -s /lib32/lib/`readlink lib32/lib/ld-linux.so.2` lib/ld-linux.so.2
-mkdir -p usr/local/tce.installed
-cat > usr/local/tce.installed/lib32 << 'EOF'
-#!/bin/sh
-echo -e "/lib32/lib\n/lib32/usr/lib\n/lib32/usr/local/lib" >> /etc/ld.so.conf
-ldconfig
-sed 's/ld-linux.*\*/ld-linux.so\*/' /usr/bin/ldd > /usr/bin/ldd32
-chmod +x /usr/bin/ldd32
-sed 's/ld-linux/ld-linux-x86-64/' /usr/bin/ldd32 > /usr/bin/ldd
-chmod +x /usr/bin/ldd
-EOF
-chmod +x usr/local/tce.installed/lib32
-chgrp -R staff usr/local/tce.installed
-chmod 775 usr/local/tce.installed
-sudo mksquashfs /tmp/lib32 lib32.tcz
-sudo mv lib32.tcz* /mnt/sda1/tce/optional/
-echo lib32.tcz >> /mnt/sda1/tce/onboot.lst 
-tce-load -i /mnt/sda1/tce/optional/lib32
-
-cd 
-
-wget http://repo.tinycorelinux.net/6.x/x86/tcz/syslinux.tcz
-tce-load -i syslinux.tcz
-
-sudo sh -c 'cat /usr/local/share/syslinux/mbr.bin > /dev/sda'
-sudo /usr/local/sbin/extlinux --install /mnt/sda1/boot/extlinux
 

--- a/packer/tinycore-linux/scripts/openvswitch.sh
+++ b/packer/tinycore-linux/scripts/openvswitch.sh
@@ -3,10 +3,14 @@
 set -x
 
 
-# We need gcc because it contain some dependencies of openvswitch
-tce-load -wi gcc.tcz
+# We need gcc libs because it contain some dependencies of openvswitch
+tce-load -wi gcc_libs
 
 tce-load -wi openvswitch-3.16.6-tinycore64
+
+# disable automatic interface configuration with dhcp
+sudo sed -i -e '/label .*core/,/append / s/\(append .*\)/\1 nodhcp/' /mnt/sda1/boot/extlinux/extlinux.conf
+echo '/sbin/udevadm settle --timeout=10' >> /opt/bootlocal.sh
 
 
 sudo modprobe openvswitch

--- a/packer/tinycore-linux/scripts/openvswitch.sh
+++ b/packer/tinycore-linux/scripts/openvswitch.sh
@@ -34,6 +34,6 @@ sudo /opt/bootlocal.sh
 
 sudo ovs-vsctl add-br br0
 
-echo 'for interface in `ip link | cut -d " " -f2 | grep "eth" | sed "s/:$//"`;do ovs-vsctl add-port br0 $interface; done'  >> /opt/bootlocal.sh
+echo 'for interface in `ip link | cut -d " " -f2 | grep "eth" | sed "s/:$//"`;do ip link set dev $interface up; ovs-vsctl add-port br0 $interface; done'  >> /opt/bootlocal.sh
 
 exit 0

--- a/packer/tinycore-linux/scripts/serial.sh
+++ b/packer/tinycore-linux/scripts/serial.sh
@@ -5,7 +5,7 @@ set -x
 # Boot configuration
 # Serial interface is secondary console, the vga console remains main console
 # To change that, exchange the two 'console=' boot parameter
-sudo sed -i -e '1 i serial 0 38400' -e '/label microcore/,/append / s/\(append .*\)/\1 console=ttyS0,38400 console=tty0/' /mnt/sda1/boot/extlinux/extlinux.conf
+sudo sed -i -e '1 i serial 0 38400' -e '/label .*core/,/append / s/\(append .*\)/\1 console=ttyS0,38400 console=tty0/' /mnt/sda1/boot/extlinux/extlinux.conf
 
 # /etc/inittab
 sudo sed -i -e '/tty6/ a ttyS0::respawn:/sbin/getty 38400 ttyS0 xterm' /etc/inittab


### PR DESCRIPTION
Changes:
- scripts/hd-install-64bits.sh: smaller syslinux-32 installation
- scripts/openvswitch.sh: load only gcc_libs, not full gcc
- scripts/openvswitch.sh: disable default network configuration with DHCP on all interfaces
- scripts/serial.sh: serial console working also with Core64

When building core64-linux.json with packer, I get this error on the start of openssh
![packer_core64_ssh](https://cloud.githubusercontent.com/assets/896406/10540570/6d526b8e-7409-11e5-8080-4414a408f37f.png)

That doesn't happen with Core 32bit. My workaround is to change "accelerator" to "kvm" (only in local copy, not on GitHub), then it works. Very strange.