### PR TITLE
Update Juniper vSRX appliance

### DIFF
--- a/appliances/juniper-vsrx.gns3a
+++ b/appliances/juniper-vsrx.gns3a
@@ -3,8 +3,6 @@
     "vendor_name": "Juniper",
     "product_name": "vSRX",
     "name": "vSRX",
-
-
     "description": "The vSRX delivers core firewall, networking, advanced security, and automated lifecycle management capabilities for enterprises and service providers. The industry\u2019s fastest virtual security platform, the vSRX offers firewall speeds up to 17 Gbps using only two virtual CPUs, providing scalable, secure protection across private, public, and hybrid clouds.",
     "maintainer_email": "developers@gns3.net",
     "documentation_url": "http://www.juniper.net/techpubs/",
@@ -13,40 +11,47 @@
     "status": "experimental",
     "vendor_url": "https://www.juniper.net",
     "registry_version": 1,
+    "usage": "Initial username is root, no password",
+    "port_name_format": "ge-0/0/{0}",
 
     "qemu": {
         "console_type": "telnet",
-        "ram": 2000,
+        "ram": 1024,
         "adapter_type": "e1000",
         "adapters": 6,
         "arch": "x86_64",
         "options": "-smp 2"
     },
 
-
     "images": [
         {
-            "version": "12.1X47.4-domestic",
+            "version": "12.1X47-D10",
             "filename": "junos-vsrx-12.1X47-D10.4-domestic.ova",
             "md5sum": "008b50d56c3a56445fd5d89616881de5",
             "filesize": 238397440,
             "download_url": "https://www.juniper.net/us/en/dm/free-vsrx-trial/"
         },
         {
-            "version": "12.1X47-D20.7-domestic",
+            "version": "12.1X47-D20",
             "filename": "junos-vsrx-12.1X47-D20.7-domestic.ova",
-            "filesize": 235960320
-            "md5sum": 5a992d618b8b40fa4a3cffd234636643,
+            "filesize": 235960320,
+            "md5sum": "5a992d618b8b40fa4a3cffd234636643",
             "download_url": "https://www.juniper.net/us/en/dm/free-vsrx-trial/"
         }
     ],
 
     "versions": [
         {
-            "name": "12.1X47.4-domestic",
+            "name": "12.1X47-D10",
             "images": {
                 "hda_disk_image": "junos-vsrx-12.1X47-D10.4-domestic.ova/junos-vsrx-12.1X47-D10.4-domestic-disk1.vmdk"
             }
+        },
+        {
+            "name": "12.1X47-D20",
+            "images": {
+                "hda_disk_image": "junos-vsrx-12.1X47-D20.7-domestic.ova/junos-vsrx-12.1X47-D20.7-domestic-disk1.vmdk"
+            }
         }
     ]
-  }
+}


### PR DESCRIPTION
- fixes errors reported by check.py
- added version, which uses junos-vsrx-12.1X47-D20.7
- changed RAM to 1024
- added port_name_format "ge-0/0/{0}"
- added usage, without usage check.py doesn't complain, but the appliance wizard does
```
PLEASE REPORT ON https://community.gns3.com/community/software/bug

Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/gns3_gui-1.4.0.dev10-py3.5.egg/gns3/dialogs/appliance_wizard.py", line 134, in initializePage
    self._appliance["usage"])
  File "/usr/local/lib/python3.5/site-packages/gns3_gui-1.4.0.dev10-py3.5.egg/gns3/registry/appliance.py", line 56, in __getitem__
    return self._appliance.__getitem__(key)
KeyError: 'usage'
```