### PR TITLE
Internet

### DIFF
--- a/appliances/internet.gns3a
+++ b/appliances/internet.gns3a
@@ -1,0 +1,41 @@
+{
+    "versions": [
+        {
+            "name": "0.1",
+            "images": {
+                "hda_disk_image": "core-linux-6.4-internet-0.1.img"
+            }
+        }
+    ],
+    "qemu": {
+        "console_type": "telnet",
+        "arch": "i386",
+        "adapters": 1,
+        "adapter_type": "e1000",
+        "options": "-device e1000,netdev=internet0 -netdev vde,sock=/var/run/vde2/qemu0.ctl,id=internet0",
+        "ram": 64
+    },
+    "vendor_name": "GNS3",
+    "usage": "Just connect stuff to the appliance. Everything is automated.",
+    "vendor_url": "http://www.gns3.com",
+    "product_name": "Internet",
+    "description": "This appliance simulate a domestic modem. It provide an IP via DHCP and will nat all connection to the internet without the need of using a cloud interface in your topologies. IP will be in the subnet 172.16.0.0/16. Multiple internet will have different IP range from 172.16.1.0/24 to 172.16.253.0/24 .\n\nWARNING USE IT ONLY WITH THE GNS3 VM.",
+    "symbol": ":/symbols/cloud.svg",
+    "maintainer": "GNS3 Team",
+    "name": "Internet",
+    "category": "router",
+    "status": "stable",
+    "registry_version": 1,
+    "maintainer_email": "developers@gns3.net",
+    "documentation_url": "http://www.gns3.com",
+    "images": [
+        {
+            "version": "0.1",
+            "filename": "core-linux-6.4-internet-0.1.img",
+            "direct_download_url": "http://downloads.sourceforge.net/project/gns-3/Qemu%20Appliances/core-linux-6.4-internet-0.1.img",
+            "filesize": 16711680,
+            "md5sum": "8ebc5a6ec53a1c05b7aa101b5ceefe31",
+            "download_url": "https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/"
+        }
+    ]
+}

--- a/packer/tinycore-linux/README.rst
+++ b/packer/tinycore-linux/README.rst
@@ -28,6 +28,16 @@ A build of Core with Openvswitch preinstalled.
 
 
 
+Internet
+''''''''
+An appliance for simulating a domestic modem. eth0 as a dhcp and eth1 should be a nat interface.
+
+.. code:: bash
+
+    packer build -var-file=core-linux-internet.json core-linux.json
+
+
+
 Tiny Core Linux installation
 ****************************
 

--- a/packer/tinycore-linux/core-linux-internet.json
+++ b/packer/tinycore-linux/core-linux-internet.json
@@ -1,0 +1,4 @@
+{
+    "vm_name": "core-linux-6.4-internet.img",
+    "setup_script": "internet.sh"
+}

--- a/packer/tinycore-linux/core-linux.json
+++ b/packer/tinycore-linux/core-linux.json
@@ -25,7 +25,8 @@
             "http_directory": "http",
             "boot_wait": "5s",
             "boot_command": [
-                "mc user=gns3<enter><wait10><wait10><wait10><wait10><wait10><wait10>",
+                "mc user=gns3<enter><wait10><wait10><wait10><wait10><wait10><wait10><wait10>",
+                "sudo udhcpc<enter>",
                 "sudo passwd gns3<enter>gns3<enter>gns3<enter>",
                 "tce-load -wi openssh<enter><wait10>",
                 "cd /usr/local/etc/ssh; [ -f sshd_config.example ] && sudo cp -a sshd_config.example sshd_config; cd<enter>",

--- a/packer/tinycore-linux/scripts/internet.sh
+++ b/packer/tinycore-linux/scripts/internet.sh
@@ -1,0 +1,46 @@
+set -x
+
+# Enable NAT
+echo "iptables -t nat -A POSTROUTING -o eth1 -j MASQUERADE" >> /opt/bootlocal.sh
+echo "iptables -A FORWARD -i eth1 -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT" >> /opt/bootlocal.sh
+echo "iptables -A FORWARD -i eth0 -o eth1 -j ACCEPT" >> /opt/bootlocal.sh
+
+
+tce-load -wi dnsmasq
+
+# Setup DHCP
+# A random IP range is choose at startup allowing user to put multiple access links
+cat > setup_dhcp_and_ip.sh << 'EOF2'
+#!/bin/sh
+
+killall udhcpc
+killall udhcpd
+killall dnsmasq 
+
+udhcpc -i eth1
+
+IP=$((RANDOM%253+1))
+
+ifconfig eth0 172.16.$IP.1 netmask 255.255.255.0 up
+
+echo "expand-hosts" >> /etc/dnsmasq.conf
+echo "no-negcache" >> /etc/dnsmasq.conf
+echo "dhcp-authoritative" >> /etc/dnsmasq.conf
+echo "dhcp-leasefile=/tmp/dhcp.leases" >> /etc/dnsmasq.conf
+echo "dhcp-range=172.16.$IP.2,172.16.$IP.254,12h" >> /etc/dnsmasq.conf
+echo "# Netmask" >> /etc/dnsmasq.conf
+echo "dhcp-option=1,255.255.255.0" >> /etc/dnsmasq.conf
+echo "# Route" >> /etc/dnsmasq.conf
+echo "dhcp-option=3,172.16.$IP.1" >> /etc/dnsmasq.conf
+
+dnsmasq
+EOF2
+
+sudo mv setup_dhcp_and_ip.sh /sbin/setup_dhcp_and_ip.sh
+sudo chmod 700 /sbin/setup_dhcp_and_ip.sh
+sudo chown root /sbin/setup_dhcp_and_ip.sh
+
+echo '/sbin/setup_dhcp_and_ip.sh' >> /opt/bootlocal.sh
+echo 'etc/dnsmasq.conf' >> /opt/.filetool.lst
+echo 'sbin/setup_dhcp_and_ip.sh' >> /opt/.filetool.lst
+


### PR DESCRIPTION
This appliance allow user to a topology in the GNS3 VM to the internet by just drag and dropping the appliance on the topology.

This appliance simulate a domestic modem. It provide an IP via DHCP and will nat all connection to the internet without the need of using a cloud interface in your topologies. IP will be in the subnet 172.16.0.0/16. Multiple internet appliance will have different IP range from 172.16.1.0/24 to 172.16.253.0/24 .

This work only with the GNS3 VM due to the use of a special vde0 (see https://github.com/GNS3/gns3-vm/pull/55)