### PR TITLE
OpenWRT (x86) appliance

### DIFF
--- a/appliances/openwrt.gns3a
+++ b/appliances/openwrt.gns3a
@@ -1,0 +1,43 @@
+{
+    "name": "OpenWrt",
+    "category": "router",
+    "description": "OpenWrt is a highly extensible GNU/Linux distribution for embedded devices (typically wireless routers). Unlike many other distributions for these routers, OpenWrt is built from the ground up to be a full-featured, easily modifiable operating system for your router. In practice, this means that you can have all the features you need with none of the bloat, powered by a Linux kernel that's more recent than most other distributions.",
+    "vendor_name": "OpenWrt",
+    "vendor_url": "http://openwrt.org", 
+    "documentation_url": "http://wiki.openwrt.org/doc/", 
+    "product_name": "OpenWrt",
+    "product_url": "http://openwrt.org", 
+    "registry_version": 1, 
+    "status": "stable",
+    "maintainer": "GNS3 Team",
+    "maintainer_email": "developers@gns3.net",
+    "usage": "Ethernet0 is the LAN link, Ethernet1 the WAN link.",
+
+    "qemu": {
+        "adapter_type": "virtio-net-pci",
+        "adapters": 2,
+        "ram": 64,
+        "arch": "i386",
+        "console_type": "telnet"
+    },
+
+    "images": [ 
+        {
+            "filename": "openwrt-15.05-x86-kvm_guest-combined-ext4.img",
+            "version": "15.05",
+            "md5sum": "c8f2635f1cc637b20bbf2fccefb77a1a",
+            "filesize": 55050240,
+            "download_url": "http://downloads.openwrt.org/chaos_calmer/15.05/x86/kvm_guest/",
+            "direct_download_url": "http://downloads.openwrt.org/chaos_calmer/15.05/x86/kvm_guest/openwrt-15.05-x86-kvm_guest-combined-ext4.img.gz"
+        }
+    ],
+
+    "versions": [
+        {
+            "name": "Chaos Calmer 15.05",
+            "images": {
+                "hda_disk_image": "openwrt-15.05-x86-kvm_guest-combined-ext4.img"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
OpenWRT Chaos Calmer 15.05 x86 version. I left out the x86 in the appliance name, because it's somehow the default.

Problem is, that the image is offered only compressed, what we can't directly use. In the GNS3a file the direct download URL points to the compressed file, but the image filename, filesize and md5sum is for the uncompressed image. As the user doesn't get any information, he is puzzled that he can directly download the file, but the image remains missing.

I suggest to create an optional message within the appliance, that is shown after the download and tells the user, what manual steps he has to do, to make a real image from the download file (in our case uncompress it with gunzip).

Maybe it can replace the openwrt-realview.gns3a, as they both have the same functions, just openwrt-realview uses the (somehow exotic) arm emulation.

With the use of the NIO:NAT it's easy to use it as an internet appliance.
![openwrt](https://cloud.githubusercontent.com/assets/896406/11096256/6fa015fe-8899-11e5-9a8d-44ba01ca5753.png)
On default it does DHCP towards the WAN(eth1) and has a DHCP server towards the LAN(eth0). It routes between WAN and LAN with NAT. So you just have to boot to have basic internet access. Furthermore it has a really nice Web GUI to make further configurations.