### PR TITLE
Windows XP+IE8 appliance

### DIFF
--- a/appliances/microsoft-windows+ie.gns3a
+++ b/appliances/microsoft-windows+ie.gns3a
@@ -1,0 +1,40 @@
+{
+    "maintainer": "GNS3 Team",
+    "vendor_name": "Microsoft",
+    "product_name": "Windows",
+    "name": "Windows",
+    "description": "Microsoft Windows (or simply Windows) is a graphical operating system developed, marketed, and sold by Microsoft.\n\nMicrosoft releases time limited VMs for testing Internet Explorer.\n\nOn the download site select the VM, as platform select VirtualBox, then download the zip file, afterwards unzip it.",
+    "maintainer_email": "developers@gns3.net",
+    "category": "guest",
+    "status": "experimental",
+    "vendor_url": "https://dev.microsoft.com/",
+    "registry_version": 1,
+
+    "qemu": {
+        "console_type": "vnc",
+        "ram": 512,
+        "adapter_type": "pcnet",
+        "adapters": 2,
+        "arch": "i386",
+        "options": "-vga std -soundhw es1370"
+    },
+
+    "images": [
+        {
+            "version": "XP+IE8",
+            "filename": "IE8 - WinXP.ova",
+            "filesize": 1241329152,
+            "md5sum": "88c74f288bc81a7aad3d610a351680ce",
+            "download_url": "http://dev.windows.com/en-us/microsoft-edge/tools/vms/windows/"
+        }
+    ],
+
+    "versions": [
+        {
+            "name": "XP+IE8",
+            "images": {
+                "hda_disk_image": "IE8 - WinXP.ova/IE8 - WinXP-disk1.vmdk"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Add Microsoft Windows XP + IE8 appliance

It uses VMs created by Microsoft. They are not activated, so they are time limited. XP is limited to 30 days, but can be rearmed several times (I read about 4 times). For testing a windows application within GNS3 this should be fine.