### PR TITLE
Windows XP: activate absolute pointer position

### DIFF
--- a/appliances/microsoft-windows+ie.gns3a
+++ b/appliances/microsoft-windows+ie.gns3a
@@ -16,7 +16,7 @@
         "adapter_type": "pcnet",
         "adapters": 2,
         "arch": "i386",
-        "options": "-vga std -soundhw es1370"
+        "options": "-vga std -soundhw es1370 -usbdevice tablet"
     },
 
     "images": [


### PR DESCRIPTION
Through the absolute pointer position feature of the USB tablet the VMs pointer position gets synchronized with the hosts pointer position. This results in a greatly enhanced user experience.