### PR TITLE
MikroTik Cloud Hosted Router appliance.

### DIFF
--- a/appliances/mikrotik-chr.gns3a
+++ b/appliances/mikrotik-chr.gns3a
@@ -1,0 +1,70 @@
+{
+    "registry_version": 1,
+    "maintainer": "GNS3 Team",
+    "maintainer_email": "developers@gns3.net",
+    "status": "stable",
+    "category": "router",
+    "vendor_name": "MikroTik",
+    "vendor_url": "http://mikrotik.com/",
+    "product_name": "MikroTik Cloud Hosted Router",
+    "product_url": "http://www.mikrotik.com/download",
+    "documentation_url": "http://wiki.mikrotik.com/wiki/Manual:CHR",
+    "name": "MikroTik CHR",
+    "description": "Cloud Hosted Router (CHR) is a RouterOS version meant for running as a virtual machine. It supports x86 64-bit architecture and can be used on most of popular hypervisors such as VMWare, Hyper-V, VirtualBox, KVM and others. CHR has full RouterOS features enabled by default but has a different licensing model than other RouterOS versions.",
+    "symbol": ":/symbols/router_firewall.svg",
+    "port_name_format": "ether{port1}",
+    "usage": "If you'd like a different sized main disk, resize the image before booting the VM for the first time.\n\nOn first boot, RouterOS is actually being installed, formatting the whole main virtual disk, before finally rebooting. That whole process may take a minute or so.\n\nThe console will become available after the installation is complete. Most Telnet/SSH clients (certainly SuperPutty) will keep retrying to connect, thus letting you know when installation is done.\n\nFrom that point on, everything about RouterOS is also true about Cloud Hosted Router, including the default credentials: Username \"admin\" and an empty password.\n\nThe primary differences between RouterOS and CHR are in support for virtual devices (this appliance comes with them being selected), and in the different license model, for which you can read more about at http://wiki.mikrotik.com/wiki/Manual:CHR.",
+    "versions": [
+        {
+            "name": "6.33.3 (.vmdk)",
+            "images": {
+                "hda_disk_image": "chr-6.33.3.vmdk"
+            }
+        },
+        {
+            "name": "6.33.2 (.vmdk)",
+            "images": {
+                "hda_disk_image": "chr-6.33.2.vmdk"
+            }
+        },
+        {
+            "name": "6.33 (.vmdk)",
+            "images": {
+                "hda_disk_image": "chr-6.33.vmdk"
+            }
+        }
+     ],
+    "images": [
+        {
+            "filesize": 23920640,
+            "md5sum": "08532a5af1a830182d65c416eab2b089",
+            "filename": "chr-6.33.3.vmdk",
+            "version": "6.33.3 (.vmdk)",
+            "download_url": "http://download2.mikrotik.com/routeros/6.33.3/chr-6.33.3.vmdk"
+        },
+        {
+            "filesize": 23920640,
+            "md5sum": "6291893c2c9626603c6d38d23390a8be",
+            "filename": "chr-6.33.2.vmdk",
+            "version": "6.33.2 (.vmdk)",
+            "download_url": "http://download2.mikrotik.com/routeros/6.33.2/chr-6.33.2.vmdk"
+        },
+        {
+            "filesize": 23920640,
+            "md5sum": "63bee5405fa1e209388adc6b5f78bb70",
+            "filename": "chr-6.33.vmdk",
+            "version": "6.33 (.vmdk)",
+            "download_url": "http://download2.mikrotik.com/routeros/6.33/chr-6.33.vmdk"
+        }
+    ],
+    "qemu": {
+        "arch": "x86_64",
+        "adapter_type": "vmxnet3",
+        "hda_disk_interface": "virtio",
+        "boot_priority": "c",
+        "ram": 64,
+        "options": "-nographic",
+        "console_type": "telnet",
+        "adapters": 2
+    }
+}


### PR DESCRIPTION
This is the reason I *really* want GNS3/gns3-gui#902. This appliance works fine on a Windows server, obviously with no KVM to begin with.

The images are all versioned with "(.vmdk)", because while all stable versions currently use this format, the next version (6.34, currently in RC stage) is *also* the point where MikroTik now distribute VDI images (which I plan to add as soon 6.34 is "official", alongside the VMDK versions) and zipped IMG files, which I'll be sure to add as soon as GNS3/gns3-gui#901 is a thing (at least for zip files...).

(There are also VHDX files, but since there's no Hyper-V support in GNS3 yet, and Qemu doesn't support this format - screw those...)

There isn't *supposed* to be a difference between the different disk image versions when they're from the same CHR version, but I've already seen the IMG of one 6.34rc version behave differently to the VMDK of that same version at install time, so just in case, the user should be allowed to use any compatible format.