### PR TITLE
Added a new version of MikroTik CHR (6.33.5)

### DIFF
--- a/appliances/mikrotik-chr.gns3a
+++ b/appliances/mikrotik-chr.gns3a
@@ -16,6 +16,24 @@
     "usage": "If you'd like a different sized main disk, resize the image before booting the VM for the first time.\n\nOn first boot, RouterOS is actually being installed, formatting the whole main virtual disk, before finally rebooting. That whole process may take a minute or so.\n\nThe console will become available after the installation is complete. Most Telnet/SSH clients (certainly SuperPutty) will keep retrying to connect, thus letting you know when installation is done.\n\nFrom that point on, everything about RouterOS is also true about Cloud Hosted Router, including the default credentials: Username \"admin\" and an empty password.\n\nThe primary differences between RouterOS and CHR are in support for virtual devices (this appliance comes with them being selected), and in the different license model, for which you can read more about at http://wiki.mikrotik.com/wiki/Manual:CHR.",
     "versions": [
         {
+            "name": "6.33.5 (.img)",
+            "images": {
+                "hda_disk_image": "chr-6.33.5.img"
+            }
+        },
+        {
+            "name": "6.33.5 (.vdi)",
+            "images": {
+                "hda_disk_image": "chr-6.33.5.vdi"
+            }
+        },
+        {
+            "name": "6.33.5 (.vmdk)",
+            "images": {
+                "hda_disk_image": "chr-6.33.5.vmdk"
+            }
+        },
+        {
             "name": "6.33.3 (.vmdk)",
             "images": {
                 "hda_disk_image": "chr-6.33.3.vmdk"
@@ -35,6 +53,28 @@
         }
      ],
     "images": [
+        {
+            "filesize": 67108864,
+            "md5sum": "210cc8ad06f25c9f27b6b99f6e00bd91",
+            "filename": "chr-6.33.5.img",
+            "version": "6.33.3 (.img)",
+            "download_url": "http://download2.mikrotik.com/routeros/6.33.5/chr-6.33.5.img.zip",
+            "compression": "zip"
+        },
+        {
+            "filesize": 24118272,
+            "md5sum": "fa84e63a558e7c61d7d338386cfd08c9",
+            "filename": "chr-6.33.5.vdi",
+            "version": "6.33.3 (.vdi)",
+            "download_url": "http://download2.mikrotik.com/routeros/6.33.5/chr-6.33.5.vdi"
+        },
+        {
+            "filesize": 23920640,
+            "md5sum": "cd284e28aa02ae59f55ed8f43ff27fbf",
+            "filename": "chr-6.33.5.vmdk",
+            "version": "6.33.3 (.vmdk)",
+            "download_url": "http://download2.mikrotik.com/routeros/6.33.5/chr-6.33.5.vmdk"
+        },
         {
             "filesize": 23920640,
             "md5sum": "08532a5af1a830182d65c416eab2b089",


### PR DESCRIPTION
Earlier today, MikroTik released a new CHR version, which comes as img, vdi, vmdk and vhdx images. This PR adds the first three.

All tested (as in "they install successfully").