### PR TITLE
KVM support in JSON schema

### DIFF
--- a/appliances/alpine-linux.gns3a
+++ b/appliances/alpine-linux.gns3a
@@ -17,7 +17,8 @@
         "adapters": 1,
         "ram": 32,
         "arch": "x86_64",
-        "console_type": "telnet"
+        "console_type": "telnet",
+        "kvm": "allow"
     },
     "images": [
         {

--- a/appliances/arista-veos.gns3a
+++ b/appliances/arista-veos.gns3a
@@ -17,7 +17,8 @@
         "adapters": 8,
         "ram": 1024,
         "arch": "x86_64",
-        "console_type": "telnet"
+        "console_type": "telnet",
+        "kvm": "require"
     },
     "images": [
         {

--- a/appliances/bird.gns3a
+++ b/appliances/bird.gns3a
@@ -16,7 +16,8 @@
         "adapters": 4,
         "ram": 128,
         "arch": "x86_64",
-        "console_type": "telnet"
+        "console_type": "telnet",
+        "kvm": "allow"
     },
     "images": [
         {

--- a/appliances/checkpoint-gaia.gns3a
+++ b/appliances/checkpoint-gaia.gns3a
@@ -18,6 +18,7 @@
         "arch": "x86_64",
         "console_type": "telnet",
         "boot_priority": "dc",
+        "kvm": "require",
         "process_priority": "normal"
     },
     "images": [

--- a/appliances/cisco-asa.gns3a
+++ b/appliances/cisco-asa.gns3a
@@ -20,6 +20,7 @@
         "arch": "i386",
         "console_type": "telnet",
         "kernel_command_line": "ide_generic.probe_mask=0x01 ide_core.chs=0.0:980,16,32 auto nousb console=ttyS0,9600 bigphysarea=65536 ide1=noprobe no-hlt",
+        "kvm": "disable",
         "options": "-no-kvm -icount auto -hdachs 980,16,32",
         "cpu_throttling": 80,
         "process_priority": "low"

--- a/appliances/cisco-asav.gns3a
+++ b/appliances/cisco-asav.gns3a
@@ -20,7 +20,8 @@
         "adapters": 8,
         "ram": 2048,
         "arch": "x86_64",
-        "console_type": "vnc"
+        "console_type": "vnc",
+        "kvm": "require"
     },
     "images": [
         {

--- a/appliances/cisco-csr1000v.gns3a
+++ b/appliances/cisco-csr1000v.gns3a
@@ -18,7 +18,8 @@
         "adapters": 4,
         "ram": 3072,
         "arch": "x86_64",
-        "console_type": "telnet"
+        "console_type": "telnet",
+        "kvm": "require"
     },
     "images": [
         {

--- a/appliances/cisco-iosv.gns3a
+++ b/appliances/cisco-iosv.gns3a
@@ -17,7 +17,8 @@
         "adapters": 4,
         "ram": 512,
         "arch": "i386",
-        "console_type": "telnet"
+        "console_type": "telnet",
+        "kvm": "require"
     },
     "images": [
         {

--- a/appliances/cisco-iosvl2.gns3a
+++ b/appliances/cisco-iosvl2.gns3a
@@ -18,7 +18,8 @@
         "adapters": 16,
         "ram": 768,
         "arch": "i386",
-        "console_type": "telnet"
+        "console_type": "telnet",
+        "kvm": "require"
     },
     "images": [
         {

--- a/appliances/cisco-iosxrv.gns3a
+++ b/appliances/cisco-iosxrv.gns3a
@@ -19,7 +19,8 @@
         "adapters": 4,
         "ram": 3072,
         "arch": "i386",
-        "console_type": "telnet"
+        "console_type": "telnet",
+        "kvm": "require"
     },
     "images": [
         {

--- a/appliances/cisco-nxosv.gns3a
+++ b/appliances/cisco-nxosv.gns3a
@@ -18,7 +18,8 @@
         "adapters": 16,
         "ram": 3072,
         "arch": "x86_64",
-        "console_type": "telnet"
+        "console_type": "telnet",
+        "kvm": "require"
     },
     "images": [
         {

--- a/appliances/cumulus-vx.gns3a
+++ b/appliances/cumulus-vx.gns3a
@@ -19,7 +19,8 @@
         "adapters": 4,
         "ram": 256,
         "arch": "x86_64",
-        "console_type": "vnc"
+        "console_type": "vnc",
+        "kvm": "require"
     },
     "images": [
         {

--- a/appliances/firefox.gns3a
+++ b/appliances/firefox.gns3a
@@ -17,7 +17,8 @@
         "adapters": 1,
         "ram": 256,
         "arch": "i386",
-        "console_type": "vnc"
+        "console_type": "vnc",
+        "kvm": "allow"
     },
     "images": [
         {

--- a/appliances/hp-vsr1001.gns3a
+++ b/appliances/hp-vsr1001.gns3a
@@ -18,7 +18,8 @@
         "ram": 1024,
         "arch": "x86_64",
         "console_type": "vnc",
-        "boot_priority": "dc"
+        "boot_priority": "dc",
+        "kvm": "require"
     },
     "images": [
         {

--- a/appliances/internet.gns3a
+++ b/appliances/internet.gns3a
@@ -18,6 +18,7 @@
         "ram": 64,
         "arch": "i386",
         "console_type": "telnet",
+        "kvm": "allow",
         "options": "-device e1000,netdev=internet0 -netdev vde,sock=/var/run/vde2/qemu0.ctl,id=internet0"
     },
     "images": [

--- a/appliances/juniper-vsrx.gns3a
+++ b/appliances/juniper-vsrx.gns3a
@@ -19,6 +19,7 @@
         "ram": 1024,
         "arch": "x86_64",
         "console_type": "telnet",
+        "kvm": "require",
         "options": "-smp 2"
     },
     "images": [

--- a/appliances/kali-linux.gns3a
+++ b/appliances/kali-linux.gns3a
@@ -16,7 +16,8 @@
         "adapters": 8,
         "ram": 1024,
         "arch": "x86_64",
-        "console_type": "vnc"
+        "console_type": "vnc",
+        "kvm": "require"
     },
     "images": [
         {

--- a/appliances/microcore-linux.gns3a
+++ b/appliances/microcore-linux.gns3a
@@ -18,7 +18,8 @@
         "adapters": 1,
         "ram": 64,
         "arch": "i386",
-        "console_type": "telnet"
+        "console_type": "telnet",
+        "kvm": "allow"
     },
     "images": [
         {

--- a/appliances/microsoft-windows+ie.gns3a
+++ b/appliances/microsoft-windows+ie.gns3a
@@ -15,6 +15,7 @@
         "ram": 512,
         "arch": "i386",
         "console_type": "vnc",
+        "kvm": "require",
         "options": "-vga std -soundhw es1370 -usbdevice tablet"
     },
     "images": [

--- a/appliances/mikrotik-chr.gns3a
+++ b/appliances/mikrotik-chr.gns3a
@@ -22,6 +22,7 @@
         "arch": "x86_64",
         "console_type": "telnet",
         "boot_priority": "c",
+        "kvm": "allow",
         "options": "-nographic"
     },
     "images": [

--- a/appliances/netem.gns3a
+++ b/appliances/netem.gns3a
@@ -18,6 +18,7 @@
         "ram": 96,
         "arch": "i386",
         "console_type": "telnet",
+        "kvm": "allow",
         "options": "-nographic"
     },
     "images": [

--- a/appliances/openbsd.gns3a
+++ b/appliances/openbsd.gns3a
@@ -18,7 +18,8 @@
         "adapters": 8,
         "ram": 256,
         "arch": "x86_64",
-        "console_type": "telnet"
+        "console_type": "telnet",
+        "kvm": "allow"
     },
     "images": [
         {

--- a/appliances/openvswitch.gns3a
+++ b/appliances/openvswitch.gns3a
@@ -15,7 +15,8 @@
         "adapters": 24,
         "ram": 128,
         "arch": "x86_64",
-        "console_type": "telnet"
+        "console_type": "telnet",
+        "kvm": "allow"
     },
     "images": [
         {

--- a/appliances/openwrt-realview.gns3a
+++ b/appliances/openwrt-realview.gns3a
@@ -17,6 +17,7 @@
         "ram": 128,
         "arch": "arm",
         "console_type": "telnet",
+        "kvm": "allow",
         "options": "-M realview-eb-mpcore"
     },
     "images": [

--- a/appliances/openwrt.gns3a
+++ b/appliances/openwrt.gns3a
@@ -17,7 +17,8 @@
         "adapters": 2,
         "ram": 64,
         "arch": "i386",
-        "console_type": "telnet"
+        "console_type": "telnet",
+        "kvm": "allow"
     },
     "images": [
         {

--- a/appliances/ostinato.gns3a
+++ b/appliances/ostinato.gns3a
@@ -20,6 +20,7 @@
         "ram": 256,
         "arch": "i386",
         "console_type": "vnc",
+        "kvm": "allow",
         "options": "-vga std -usbdevice tablet"
     },
     "images": [

--- a/appliances/tinycore-linux.gns3a
+++ b/appliances/tinycore-linux.gns3a
@@ -18,7 +18,8 @@
         "adapters": 1,
         "ram": 96,
         "arch": "i386",
-        "console_type": "vnc"
+        "console_type": "vnc",
+        "kvm": "allow"
     },
     "images": [
         {

--- a/appliances/vrin.gns3a
+++ b/appliances/vrin.gns3a
@@ -15,7 +15,8 @@
         "adapters": 1,
         "ram": 256,
         "arch": "x86_64",
-        "console_type": "telnet"
+        "console_type": "telnet",
+        "kvm": "allow"
     },
     "images": [
         {

--- a/appliances/vyos.gns3a
+++ b/appliances/vyos.gns3a
@@ -20,7 +20,8 @@
         "ram": 512,
         "arch": "x86_64",
         "console_type": "telnet",
-        "boot_priority": "dc"
+        "boot_priority": "dc",
+        "kvm": "allow"
     },
     "images": [
         {

--- a/patch_appliance.py
+++ b/patch_appliance.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2015 GNS3 Technologies Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+This file is sample tools for patching all appliances. It's usefull when
+you need to add a property to all appliances.
+"""
+
+import glob
+import sys
+import json
+import jsonschema
+
+def ask(question, type='string', optional=False):
+    while True:
+        if optional:
+            sys.stdout.write(question + "(optional leave blank for skip) : ")
+        else:
+            sys.stdout.write(question + ": ")
+        sys.stdout.flush()
+        val = sys.stdin.readline().strip()
+        if len(val) == 0:
+            if optional:
+                return None
+            continue
+        if type == 'integer':
+            try:
+                val = int(val)
+            except ValueError:
+                continue
+        sys.stdout.write("\n")
+        return val
+
+
+def ask_multiple(question, options, optional=False):
+    while True:
+        for i, option in enumerate(options):
+            question += '\n{}) {}'.format(i + 1, option)
+        question += '\n'
+        answer = ask(question, type='integer', optional=optional)
+        if answer is None:
+            if optional:
+                return None
+        else:
+            if answer > 0 and answer <= len(options):
+                return options[answer - 1]
+
+
+with open('schemas/appliance.json') as f:
+    schema = json.load(f)
+
+for appliance in glob.glob('appliances/*.gns3a'):
+    print('=> Patch', appliance)
+    # Load appliance
+    with open(appliance) as f:
+        config = json.load(f)
+
+    # Our patch
+    if not 'qemu' in config:
+        continue
+    config['qemu']['kvm'] = ask_multiple('KVM support for {}'.format(appliance), ['require', 'allow', 'disable'])
+
+    # Validate our changes
+    jsonschema.validate(config, schema)
+
+    # Save
+    with open(appliance, 'w') as f:
+        json.dump(config, f,indent=4)

--- a/schemas/appliance.json
+++ b/schemas/appliance.json
@@ -245,6 +245,10 @@
             "type": "string",
             "title": "Command line parameters send to the kernel"
         },
+        "kvm": {
+            "title": "KVM requirements",
+            "enum": ["require", "allow", "disable"]
+        },
         "options": {
             "type": "string",
             "title": "Optional additional qemu command line options"
@@ -272,7 +276,8 @@
           "adapters",
           "ram",
           "arch",
-          "console_type"
+          "console_type",
+          "kvm"
       ]
     },
     "images": {


### PR DESCRIPTION
This PR add KVM support in the appliance schema.
It's a part of https://github.com/GNS3/gns3-gui/issues/904 from
@boenrobot

KVM has three value:
* "require" - Forbid installation on the target server if KVM is not
available there (i.e. a Windows and OSX; be it local or remote). Install
only with KVM enabled.
* "allow" - Enable KVM if supported on the target server, but allow
installation to continue with KVM disabled if not supported (this should
be the default).
* "disable" - Even if KVM is supported on the target server, install with
KVM disabled.

All appliances have been updated to reflect their correct value.

Also it's add a sample tool for quickly patch all appliances.