### PR TITLE
FortiGate appliance

### DIFF
--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -40,7 +40,8 @@
             "version": "1.0",
             "md5sum": "3411a599e822f2ac6be560a26405821a",
             "filesize": 197120,
-            "download_url": "https://sourceforge.net/projects/gns-3/files/Empty%20Qemu%20disk/"
+            "download_url": "https://sourceforge.net/projects/gns-3/files/Empty%20Qemu%20disk/",
+            "direct_download_url": "http://sourceforge.net/projects/gns-3/files/Empty%20Qemu%20disk/empty30G.qcow2/download"
         }
 
     ],

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -23,8 +23,8 @@
         "console_type": "telnet",
         "ram": 1024,
         "arch": "x86_64",
-        "boot_priority": "hdd",
-	"kvm": "allow"
+        "boot_priority": "c",
+        "kvm": "allow"
     },
 
     "images": [

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -28,12 +28,11 @@
 
     "images": [
         {
-            "filename": "fortios.qcow2",
+            "filename": "FGT_VM64_KVM-v5-build0701-FORTINET.out.kvm.qcow2",
             "version": "5.2.5",
             "md5sum": "c4d2cbe51669796e48623e006782f7dc",
             "filesize": 33902592,
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx",
-            "direct_download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
 	{
             "filename": "empty30G.qcow2",
@@ -41,7 +40,6 @@
             "md5sum": "3411a599e822f2ac6be560a26405821a",
             "filesize": 197120,
             "download_url": "https://sourceforge.net/projects/gns-3/files/Empty%20Qemu%20disk/",
-            "direct_download_url": "http://downloads.sourceforge.net/project/gns-3/Empty Qemu disk/empty30G.qcow2"
         }
 
     ],
@@ -50,7 +48,7 @@
         {
             "name": "5.2.5",
             "images": {
-                "hda_disk_image": "fortios.qcow2"
+                "hda_disk_image": "fortios.qcow2",
                 "hdb_disk_image": "empty30G.qcow2"
             }
         },

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -49,7 +49,7 @@
         {
             "name": "5.2.5",
             "images": {
-                "hda_disk_image": "fortios.qcow2",
+                "hda_disk_image": "FGT_VM64_KVM-v5-build0701-FORTINET.out.kvm.qcow2",
                 "hdb_disk_image": "empty30G.qcow2"
             }
         }

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -12,7 +12,7 @@
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
     "usage": "Default username is admin, no password is set.",
-    "port_name_format": "port{0}",
+    "port_name_format": "Port{port1}",
     "linked_base": false,
 
     "qemu": {

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -1,71 +1,58 @@
 {
-    "name": "VyOS",
-    "category": "router",
-    "description": "VyOS is a community fork of Vyatta, a Linux-based network operating system that provides software-based network routing, firewall, and VPN functionality.",
-    "vendor_name": "Linux",
-    "vendor_url": "http://vyos.net/",
-    "documentation_url": "http://vyos.net/wiki/User_Guide",
-    "product_name": "VyOS",
-    "product_url": "http://vyos.net/",
+    "name": "FortiGate",
+    "category": "firewall",
+    "description": "FortiGate Virtual Appliance offers the same level of advanced threat prevention features like the physical appliances in private, hybrid and public cloud deployment.",
+    "vendor_name": "Fortinet",
+    "vendor_url": "http://www.fortinet.com/",
+    "documentation_url": "http://docs.fortinet.com/p/inside-fortios",
+    "product_name": "FortiGate",
+    "product_url": "http://www.fortinet.com/products/fortigate/virtual-appliances.html",
     "registry_version": 1,
     "status": "stable",
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
-    "usage": "Default username/password is vyos/vyos. At first boot the router will start from the cdrom, login and then type install system and follow the instructions. Finally type poweroff and activate the linked base setting in your VM template in the GNS3 preferences.",
-    "port_name_format": "eth{0}",
+    "usage": "Default username is admin, no password is set.",
+    "port_name_format": "port{0}",
     "linked_base": false,
 
     "qemu": {
-        "adapter_type": "e1000",
-        "adapters": 3,
+        "adapter_type": "virtio-net-pci",
+	"hda_disk_interface": "virtio",
+	"hdb_disk_interface": "virtio",
+        "adapters": 10,
         "console_type": "telnet",
-        "ram": 512,
+        "ram": 1024,
         "arch": "x86_64",
-        "boot_priority": "dc"
+        "boot_priority": "hdd"
     },
 
     "images": [
         {
-            "filename": "vyos-1.1.6-amd64.iso",
-            "version": "1.1.6",
-            "md5sum": "3128954d026e567402a924c2424ce2bf",
-            "filesize": 245366784,
-            "download_url": "http://mirror.vyos.net/iso/release/1.1.6/",
-            "direct_download_url": "http://mirror.vyos.net/iso/release/1.1.6/vyos-1.1.6-amd64.iso"
+            "filename": "fortios.qcow2",
+            "version": "5.2.5",
+            "md5sum": "c4d2cbe51669796e48623e006782f7dc",
+            "filesize": 33902592,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx",
+            "direct_download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
-        {
-            "filename": "vyos-1.1.5-amd64.iso",
-            "version": "1.1.5",
-            "md5sum": "193179532011ceaa87ee725bd8f22022",
-            "filesize": 247463936,
-            "download_url": "http://mirror.vyos.net/iso/release/1.1.5/",
-            "direct_download_url": "http://mirror.vyos.net/iso/release/1.1.5/vyos-1.1.5-amd64.iso"
-        },
-        {
-            "filename": "empty8G.qcow2",
+	{
+            "filename": "empty30G.qcow2",
             "version": "1.0",
-            "md5sum": "f1d2c25b6990f99bd05b433ab603bdb4",
+            "md5sum": "3411a599e822f2ac6be560a26405821a",
             "filesize": 197120,
             "download_url": "https://sourceforge.net/projects/gns-3/files/Empty%20Qemu%20disk/",
-            "direct_download_url": "http://downloads.sourceforge.net/project/gns-3/Empty Qemu disk/empty8G.qcow2"
+            "direct_download_url": "http://downloads.sourceforge.net/project/gns-3/Empty Qemu disk/empty30G.qcow2"
         }
 
     ],
 
     "versions": [
         {
-            "name": "1.1.6",
+            "name": "5.2.5",
             "images": {
-                "cdrom_image": "vyos-1.1.6-amd64.iso",
-                "hda_disk_image": "empty8G.qcow2"
+                "hda_disk_image": "fortios.qcow2"
+                "hdb_disk_image": "empty30G.qcow2"
             }
         },
-        {
-            "name": "1.1.5",
-            "images": {
-                "cdrom_image": "vyos-1.1.5-amd64.iso",
-                "hda_disk_image": "empty8G.qcow2"
-            }
-        }
     ]
 }

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -1,0 +1,71 @@
+{
+    "name": "VyOS",
+    "category": "router",
+    "description": "VyOS is a community fork of Vyatta, a Linux-based network operating system that provides software-based network routing, firewall, and VPN functionality.",
+    "vendor_name": "Linux",
+    "vendor_url": "http://vyos.net/",
+    "documentation_url": "http://vyos.net/wiki/User_Guide",
+    "product_name": "VyOS",
+    "product_url": "http://vyos.net/",
+    "registry_version": 1,
+    "status": "stable",
+    "maintainer": "GNS3 Team",
+    "maintainer_email": "developers@gns3.net",
+    "usage": "Default username/password is vyos/vyos. At first boot the router will start from the cdrom, login and then type install system and follow the instructions. Finally type poweroff and activate the linked base setting in your VM template in the GNS3 preferences.",
+    "port_name_format": "eth{0}",
+    "linked_base": false,
+
+    "qemu": {
+        "adapter_type": "e1000",
+        "adapters": 3,
+        "console_type": "telnet",
+        "ram": 512,
+        "arch": "x86_64",
+        "boot_priority": "dc"
+    },
+
+    "images": [
+        {
+            "filename": "vyos-1.1.6-amd64.iso",
+            "version": "1.1.6",
+            "md5sum": "3128954d026e567402a924c2424ce2bf",
+            "filesize": 245366784,
+            "download_url": "http://mirror.vyos.net/iso/release/1.1.6/",
+            "direct_download_url": "http://mirror.vyos.net/iso/release/1.1.6/vyos-1.1.6-amd64.iso"
+        },
+        {
+            "filename": "vyos-1.1.5-amd64.iso",
+            "version": "1.1.5",
+            "md5sum": "193179532011ceaa87ee725bd8f22022",
+            "filesize": 247463936,
+            "download_url": "http://mirror.vyos.net/iso/release/1.1.5/",
+            "direct_download_url": "http://mirror.vyos.net/iso/release/1.1.5/vyos-1.1.5-amd64.iso"
+        },
+        {
+            "filename": "empty8G.qcow2",
+            "version": "1.0",
+            "md5sum": "f1d2c25b6990f99bd05b433ab603bdb4",
+            "filesize": 197120,
+            "download_url": "https://sourceforge.net/projects/gns-3/files/Empty%20Qemu%20disk/",
+            "direct_download_url": "http://downloads.sourceforge.net/project/gns-3/Empty Qemu disk/empty8G.qcow2"
+        }
+
+    ],
+
+    "versions": [
+        {
+            "name": "1.1.6",
+            "images": {
+                "cdrom_image": "vyos-1.1.6-amd64.iso",
+                "hda_disk_image": "empty8G.qcow2"
+            }
+        },
+        {
+            "name": "1.1.5",
+            "images": {
+                "cdrom_image": "vyos-1.1.5-amd64.iso",
+                "hda_disk_image": "empty8G.qcow2"
+            }
+        }
+    ]
+}

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -32,14 +32,14 @@
             "version": "5.2.5",
             "md5sum": "c4d2cbe51669796e48623e006782f7dc",
             "filesize": 33902592,
-            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx",
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
             "filename": "empty30G.qcow2",
             "version": "1.0",
             "md5sum": "3411a599e822f2ac6be560a26405821a",
             "filesize": 197120,
-            "download_url": "https://sourceforge.net/projects/gns-3/files/Empty%20Qemu%20disk/",
+            "download_url": "https://sourceforge.net/projects/gns-3/files/Empty%20Qemu%20disk/"
         }
 
     ],

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -51,6 +51,6 @@
                 "hda_disk_image": "fortios.qcow2",
                 "hdb_disk_image": "empty30G.qcow2"
             }
-        },
+        }
     ]
 }

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -23,7 +23,8 @@
         "console_type": "telnet",
         "ram": 1024,
         "arch": "x86_64",
-        "boot_priority": "hdd"
+        "boot_priority": "hdd",
+	"kvm": "allow"
     },
 
     "images": [

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -17,8 +17,8 @@
 
     "qemu": {
         "adapter_type": "virtio-net-pci",
-	"hda_disk_interface": "virtio",
-	"hdb_disk_interface": "virtio",
+        "hda_disk_interface": "virtio",
+        "hdb_disk_interface": "virtio",
         "adapters": 10,
         "console_type": "telnet",
         "ram": 1024,
@@ -34,7 +34,7 @@
             "filesize": 33902592,
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx",
         },
-	{
+        {
             "filename": "empty30G.qcow2",
             "version": "1.0",
             "md5sum": "3411a599e822f2ac6be560a26405821a",


### PR DESCRIPTION
5.4.0 has not been added yet because only an update package is available to download. Will check later.