### PR TITLE
Have a look at my version of check_url.py

### DIFF
--- a/check_urls_be.py
+++ b/check_urls_be.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2015 GNS3 Technologies Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import json
+import sys
+import pycurl
+
+err_list = []
+
+def check_url(url, appliance):
+    print("   " + url)
+
+    error = None
+    try:
+        c = pycurl.Curl()
+        c.setopt(c.URL, url)
+        c.setopt(c.USERAGENT, 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)')
+        c.setopt(c.NOBODY, True)
+        c.perform()
+        http_status = c.getinfo(c.RESPONSE_CODE)
+        if http_status >= 400:
+            error = 'HTTP status {}'.format(http_status)
+        c.close()
+    except pycurl.error:
+        error = c.errstr()
+
+    if error:
+        print("     " + error)
+        err_list.append("{}: {} - {}".format(appliance, url, error))
+
+
+def check_urls(appliance):
+    try:
+        with open(os.path.join('appliances', appliance)) as f:
+            appliance_json = json.load(f)
+    except Exception as err:
+        print("   " + str(err))
+        err_list.append("{}: {}".format(appliance, err))
+        return []
+
+    urls = set()
+
+    for image in appliance_json['images']:
+        if 'direct_download_url' in image:
+            urls.add(image['direct_download_url'])
+        if 'download_url' in image:
+            urls.add(image['download_url'])
+
+    if 'vendor_url' in appliance_json:
+        urls.add(appliance_json['vendor_url'])
+    if 'documentation_url' in appliance_json:
+        urls.add(appliance_json['documentation_url'])
+    if 'product_url' in appliance_json:
+        urls.add(appliance_json['product_url'])
+    return list(urls)
+
+
+def main():
+    print("=> Check URL in appliances")
+    if len(sys.argv) >= 2:
+        appliance_list = sys.argv[1:]
+    else:
+        appliance_list = os.listdir('appliances')
+        appliance_list.sort()
+
+    for appliance in appliance_list:
+        if not appliance.endswith('.gns3a'):
+            appliance += '.gns3a'
+        print("-> {}".format(appliance))
+        for url in check_urls(appliance):
+            check_url(url, appliance)
+        print()
+
+    if len(err_list) == 0:
+         print("Everything is ok!")
+    else:
+        print("{} error(s):".format(len(err_list)))
+        for error in err_list:
+            print(error)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is not a normal pull request, as I don't expect that you merge it. It's more a way to show you my version of check_url.py

The current check_url.py has some drawbacks:
* It terminates at the first error. Sad enough there is (almost) some web site, that don't work. Therefore an error is not necessarily a problem of the registry. Currently https://www.cumulusnetworks.com seems to be down and https://dev.microsoft.com/ has an invalid certificate
* Some websites (e.g. http://www.gns3.com) refuse the connection, when the user agent is not a well-known one
* You can't check some few appliances

I decided to use pycurl, because it's rock stable, has a simple interface and creates good error messages. Drawback is, that is has to be installed ```pip3 install pycurl```.

Here the current errors, none is the fault of a bad appliance:
```
4 error(s):
cumulus-vx.gns3a: https://cumulusnetworks.com/cumulus-vx/ - Server aborted the SSL handshake
cumulus-vx.gns3a: https://cumulusnetworks.com/cumulus-vx/download/ - Server aborted the SSL handshake
cumulus-vx.gns3a: https://www.cumulusnetworks.com - Server aborted the SSL handshake
microsoft-windows+ie.gns3a: https://dev.microsoft.com/ - SSL certificate problem: Invalid certificate chain
```