### PR TITLE
use GET requests instead of HEAD for checking URLs

### DIFF
--- a/appliances/microsoft-windows+ie.gns3a
+++ b/appliances/microsoft-windows+ie.gns3a
@@ -3,7 +3,7 @@
     "category": "guest",
     "description": "Microsoft Windows (or simply Windows) is a graphical operating system developed, marketed, and sold by Microsoft.\n\nMicrosoft releases time limited VMs for testing Internet Explorer.\n\nOn the download site select the VM, as platform select VirtualBox, then download the zip file, afterwards unzip it.",
     "vendor_name": "Microsoft",
-    "vendor_url": "https://dev.microsoft.com/",
+    "vendor_url": "http://www.microsoft.com",
     "product_name": "Windows",
     "registry_version": 1,
     "status": "experimental",

--- a/check_urls.py
+++ b/check_urls.py
@@ -22,6 +22,11 @@ import pycurl
 
 err_list = []
 
+
+def data_abort(data):
+    return -1
+
+
 def check_url(url, appliance):
     print("   " + url)
 
@@ -30,15 +35,17 @@ def check_url(url, appliance):
         c = pycurl.Curl()
         c.setopt(c.URL, url)
         c.setopt(c.USERAGENT, 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)')
-        c.setopt(c.NOBODY, True)
         c.setopt(c.FOLLOWLOCATION, True)
+        c.setopt(c.WRITEFUNCTION, data_abort)
         c.perform()
         http_status = c.getinfo(c.RESPONSE_CODE)
         if http_status >= 400:
             error = 'HTTP status {}'.format(http_status)
         c.close()
-    except pycurl.error:
-        error = c.errstr()
+    except pycurl.error as err:
+        errno, errstr = err.args
+        if errno != pycurl.E_WRITE_ERROR:
+            error = errstr
 
     if error:
         print("     " + error)

--- a/check_urls.py
+++ b/check_urls.py
@@ -31,25 +31,29 @@ def check_url(url, appliance):
     print("   " + url)
 
     error = None
+    c = pycurl.Curl()
     try:
-        c = pycurl.Curl()
         c.setopt(c.URL, url)
         c.setopt(c.USERAGENT, 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)')
+        c.setopt(c.HTTPHEADER, ['Accept-Language: en-us'])
         c.setopt(c.FOLLOWLOCATION, True)
         c.setopt(c.WRITEFUNCTION, data_abort)
         c.perform()
-        http_status = c.getinfo(c.RESPONSE_CODE)
-        if http_status >= 400:
-            error = 'HTTP status {}'.format(http_status)
-        c.close()
     except pycurl.error as err:
         errno, errstr = err.args
         if errno != pycurl.E_WRITE_ERROR:
             error = errstr
 
+    if not error:
+        http_status = c.getinfo(c.RESPONSE_CODE)
+        if http_status >= 400:
+            error = 'HTTP status {}'.format(http_status)
+
     if error:
         print("     " + error)
         err_list.append("{}: {} - {}".format(appliance, url, error))
+
+    c.close()
 
 
 def check_urls(appliance):


### PR DESCRIPTION
As dev.windows.com (and potentially some other sites) doesn't like HEAD request, check_url now uses GET requests, which will aborted as soon as some data coming in.

Furthermore changed the microsoft vendor URL to http://www.microsoft.com, which didn't work with the old check_url.

Now the check_url manages to run without errors.