### PR TITLE
Changed 'GigabitEthernet' to 'Gi'

### DIFF
--- a/appliances/cisco-asa.gns3a
+++ b/appliances/cisco-asa.gns3a
@@ -12,7 +12,7 @@
     "maintainer_email": "developers@gns3.net",
     "usage": "This appliance will use 100% of your CPU, please use ASAv instead. There is no default password and enable password.",
     "symbol": ":/symbols/asa.svg",
-    "port_name_format": "GigabitEthernet{0}",
+    "port_name_format": "Gi{0}",
     "qemu": {
         "adapter_type": "i82559er",
         "adapters": 4,

--- a/appliances/cisco-asav.gns3a
+++ b/appliances/cisco-asav.gns3a
@@ -14,7 +14,7 @@
     "usage": "There is no default password and enable password. A default configuration is present.",
     "symbol": ":/symbols/asa.svg",
     "first_port_name": "Management0/0",
-    "port_name_format": "GigabitEthernet0/{0}",
+    "port_name_format": "Gi0/{0}",
     "qemu": {
         "adapter_type": "e1000",
         "adapters": 8,

--- a/appliances/cisco-csr1000v.gns3a
+++ b/appliances/cisco-csr1000v.gns3a
@@ -12,7 +12,7 @@
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
     "usage": "There is no default password and enable password. A default configuration is present.",
-    "port_name_format": "GigabitEthernet{0}",
+    "port_name_format": "Gi{0}",
     "qemu": {
         "adapter_type": "virtio-net-pci",
         "adapters": 4,

--- a/appliances/cisco-iosv.gns3a
+++ b/appliances/cisco-iosv.gns3a
@@ -11,7 +11,7 @@
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
     "usage": "There is no default password and enable password. There is no default configuration present.",
-    "port_name_format": "GigabitEthernet0/{0}",
+    "port_name_format": "Gi0/{0}",
     "qemu": {
         "adapter_type": "e1000",
         "adapters": 4,

--- a/appliances/cisco-iosvl2.gns3a
+++ b/appliances/cisco-iosvl2.gns3a
@@ -11,7 +11,7 @@
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
     "usage": "There is no default password and enable password. There is no default configuration present.",
-    "port_name_format": "GigabitEthernet{1}/{0}",
+    "port_name_format": "Gi{1}/{0}",
     "port_segment_size": 4,
     "qemu": {
         "adapter_type": "e1000",


### PR DESCRIPTION
It was too long and was shown as 'Gigabite' in the GUI. Basically did the same for all Cisco templates that I did for IOS-XR (as discussed in issue #100).