### PR TITLE
Added ipterm and webterm

### DIFF
--- a/appliances/ipterm.gns3a
+++ b/appliances/ipterm.gns3a
@@ -1,0 +1,18 @@
+{
+    "name": "ipterm",
+    "category": "guest",
+    "description": "ipterm is a debian based networking toolbox.\nIt contains the following utilities: net-tools, iproute2, ping, traceroute, iperf3, ssh client, tcpdump and the multicast testing tools msend/mreceive.",
+    "vendor_name": "ipterm",
+    "vendor_url": "https://www.debian.org",
+    "product_name": "ipterm",
+    "registry_version": 3,
+    "status": "stable",
+    "maintainer": "GNS3 Team",
+    "maintainer_email": "developers@gns3.net",
+    "usage": "The /root directory is persistent.",
+    "symbol": "linux_guest.svg",
+    "docker": {
+        "adapters": 1,
+        "image": "gns3/ipterm"
+    }
+}

--- a/appliances/webterm.gns3a
+++ b/appliances/webterm.gns3a
@@ -1,0 +1,19 @@
+{
+    "name": "webterm",
+    "category": "guest",
+    "description": "webterm is a debian based networking toolbox.\nIt contains the firefox web browser plus the following utilities: net-tools, iproute2, ping, traceroute, iperf3, ssh client, tcpdump and the multicast testing tools msend/mreceive.",
+    "vendor_name": "webterm",
+    "vendor_url": "https://www.debian.org",
+    "product_name": "webterm",
+    "registry_version": 3,
+    "status": "stable",
+    "maintainer": "GNS3 Team",
+    "maintainer_email": "developers@gns3.net",
+    "usage": "The /root directory is persistent.",
+    "symbol": "firefox.svg",
+    "docker": {
+        "adapters": 1,
+        "image": "gns3/webterm",
+        "console_type": "vnc"
+    }
+}

--- a/docker/ipterm/README.md
+++ b/docker/ipterm/README.md
@@ -1,0 +1,47 @@
+# ipterm - Networking Toolbox
+
+This appliance contains the following networking tools:
+
+- net-tools (basic network administration tools)
+- iproute2 (advanced network administration tools)
+- ping and traceroute
+- iperf3
+- ssh client
+- tcpdump
+- telnet
+- mtools (multicast tools msend & mreceive),
+  see https://github.com/troglobit/mtools
+
+It is divided into several sub-images:
+
+- ipterm-base  
+  This image includes the common utilities mentioned previously.
+  It creates the foundation for the next images.
+  It's not intended, that the user directly uses this image.
+- ipterm  
+  Based on ipterm-base it sets bash as the default command and
+  uses /root as a persistent directory.
+- webterm  
+  This adds the Firefox web browser to ipterm-base.
+  Like ipterm, the /root directory is persistent.
+
+## Build and publish the Images
+
+First the base image has to be created:
+
+```
+docker build -t gns3/ipterm-base base
+docker push gns3/ipterm-base    (optional)
+```
+
+Afterwards the cli and/or the web image can be built:
+
+```
+docker build -t gns3/ipterm cli
+docker push gns3/ipterm
+```
+
+```
+docker build -t gns3/webterm web
+docker push gns3/webterm
+```

--- a/docker/ipterm/base/Dockerfile
+++ b/docker/ipterm/base/Dockerfile
@@ -1,0 +1,29 @@
+# docker base image for basic networking tools
+
+FROM debian:jessie
+
+RUN set -ex \
+    && apt-get update \
+#
+# compile and install mtools (msend & mreceive)
+#
+    && dpkg-query -f '${binary:Package}\n' -W | sort > base_packages \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+        gcc libc6-dev make curl ca-certificates \
+    && curl -OL https://github.com/troglobit/mtools/releases/download/v2.3/mtools-2.3.tar.gz \
+    && tar xfz mtools-2.3.tar.gz \
+    && cd mtools-2.3 \
+    && make \
+    && make install \
+    && cd .. \
+    && rm -r mtools-2.3* \
+    && dpkg-query -f '${binary:Package}\n' -W | sort > packages \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y purge \
+        `comm -13 base_packages packages` \
+    && rm -f base_packages packages \
+#
+# install remaining tools
+#
+    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+        net-tools tcpdump telnet traceroute iperf3 openssh-client vim-tiny \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker/ipterm/cli/Dockerfile
+++ b/docker/ipterm/cli/Dockerfile
@@ -1,0 +1,6 @@
+# docker image with basic networking tools
+
+FROM gns3/ipterm-base
+
+VOLUME [ "/root" ]
+CMD [ "sh", "-c", "cd; exec bash -i" ]

--- a/docker/ipterm/web/Dockerfile
+++ b/docker/ipterm/web/Dockerfile
@@ -1,0 +1,59 @@
+# docker image with basic networking tools and web browser
+
+FROM gns3/ipterm-base
+
+# minimal init, see https://github.com/Yelp/dumb-init
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.1.0/dumb-init_1.1.0_amd64 /usr/local/sbin/dumb-init
+
+RUN set -ex \
+    && chmod 755 /usr/local/sbin/dumb-init \
+    && apt-get update \
+#
+# install web tools
+#
+    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+        firefox-esr lxterminal jwm menu \
+    && rm -rf /var/lib/apt/lists/* \
+    && /bin/echo -e '\
+\x23!/bin/sh\n\
+\n\
+\x23 use home page on first start\n\
+[ -e "$HOME/.mozilla" ] || start_url="about:home"\n\
+\n\
+\x23 start firefox\n\
+start=$(date +%s)\n\
+firefox $start_url\n\
+status=$?\n\
+\n\
+\x23 workaround: restart firefox, if it crashes during initialization\n\
+if [ $status -eq 139 -a $(($(date +%s)-start)) -le 10 ]; then\n\
+        firefox $start_url\n\
+fi' \
+        > /usr/local/bin/start-firefox; chmod +x /usr/local/bin/start-firefox \
+    && /bin/echo -e '\
+?package(firefox-esr):\\\n\
+ needs="x11"\\\n\
+ section="Applications"\\\n\
+ title="Mozilla Firefox"\\\n\
+ command="start-firefox"' \
+        > /etc/menu/firefox \
+    && echo "postrun="\""sed -i '/^    </ d' debian-menu"\" >> /etc/menu-methods/jwm \
+    && sed -i 's/\(Desktops width\)="[0-9]*"/\1="2"/' /etc/jwm/system.jwmrc \
+    && update-menus \
+    && mkdir -p /root/.config/lxterminal \
+    && /bin/echo -e '\
+[general]\n\
+scrollback=1000\n\
+fgcolor=#ffffff' \
+        > /root/.config/lxterminal/lxterminal.conf \
+    && /bin/echo -e '\
+\x23!/bin/sh\n\
+\n\
+cd\n\
+export SHELL=/bin/bash\n\
+start-firefox &\n\
+jwm' \
+        > /start_browser.sh; chmod +x /start_browser.sh
+
+VOLUME [ "/root" ]
+CMD [ "dumb-init", "/start_browser.sh" ]


### PR DESCRIPTION
ipterm and webterm are debian based networking toolboxes using docker.

I'm using ipterm as a replacement for VPCS.

webterm is the GUI version with an additionally firefox web browser (and a display manager and a graphical terminal emulator to have a decent GUI).

Of course, I can't publish the docker images into the gns3 docker hub, that's left to the GNS3 team.