### PR TITLE
New Fortinet versions & pfSense fix

### DIFF
--- a/appliances/fortiadc.gns3a
+++ b/appliances/fortiadc.gns3a
@@ -27,6 +27,13 @@
     },
     "images": [
         {
+            "filename": "FAD_KVM-v400-build0581-FORTINET.out.kvm-boot.qcow2",
+            "version": "4.5.1",
+            "md5sum": "bfc93d5881dda3f0a3123f54665bdcf0",
+            "filesize": 67305472,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FAD_KVM-v400-build0560-FORTINET.out.kvm-boot.qcow2",
             "version": "4.5.0",
             "md5sum": "7a71f52bde93c0000b047626731b7aef",
@@ -34,8 +41,8 @@
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
-            "filename": "FAD_KVM-v400-build0560-FORTINET.out.kvm-data.qcow2",
-            "version": "4.5.0",
+            "filename": "FAD_KVM-v400-FORTINET.out.kvm-data.qcow2",
+            "version": "4.5.x",
             "md5sum": "b7500835594e62d8acb1c6ec43d597c1",
             "filesize": 30998528,
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
@@ -43,10 +50,17 @@
     ],
     "versions": [
         {
+            "name": "4.5.1",
+            "images": {
+                "hda_disk_image": "FAD_KVM-v400-build0581-FORTINET.out.kvm-boot.qcow2",
+                "hdb_disk_image": "FAD_KVM-v400-FORTINET.out.kvm-data.qcow2"
+            }
+        },
+        {
             "name": "4.5.0",
             "images": {
                 "hda_disk_image": "FAD_KVM-v400-build0560-FORTINET.out.kvm-boot.qcow2",
-                "hdb_disk_image": "FAD_KVM-v400-build0560-FORTINET.out.kvm-data.qcow2"
+                "hdb_disk_image": "FAD_KVM-v400-FORTINET.out.kvm-data.qcow2"
             }
         }
     ]

--- a/appliances/fortimail.gns3a
+++ b/appliances/fortimail.gns3a
@@ -26,6 +26,13 @@
     },
     "images": [
         {
+            "filename": "FML_VMKV-64-v53-build0599-FORTINET.out.kvm.qcow2",
+            "version": "5.3.3",
+            "md5sum": "f1f3ae5593029d4fc0a5024bcf786cc7",
+            "filesize": 84606976,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FML_VMKV-64-v53-build0593-FORTINET.out.kvm.qcow2",
             "version": "5.3.2",
             "md5sum": "0447819ed4aa382ea6871c0cb913b592",
@@ -42,6 +49,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "5.3.3",
+            "images": {
+                "hda_disk_image": "FML_VMKV-64-v53-build0599-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
         {
             "name": "5.3.2",
             "images": {

--- a/appliances/fortiweb.gns3a
+++ b/appliances/fortiweb.gns3a
@@ -26,6 +26,13 @@
     },
     "images": [
         {
+            "filename": "FWB_KVM-v500-build0730-FORTINET.out.kvm-boot.qcow2",
+            "version": "5.5.3",
+            "md5sum": "12ebec432a54900e6c63540af8ebfbb4",
+            "filesize": 87228416,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FWB_KVM-v500-build0723-FORTINET.out.kvm-boot.qcow2",
             "version": "5.5.2",
             "md5sum": "0a613191948d3618ae16cd9f11988448",
@@ -33,8 +40,8 @@
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
-            "filename": "FWB_KVM-v500-build0723-FORTINET.out.kvm-log.qcow2",
-            "version": "5.5.2",
+            "filename": "FWB_KVM-v500-FORTINET.out.kvm-log.qcow2",
+            "version": "5.5.x",
             "md5sum": "b90cd0a382cb09db31cef1d0cdf7d6e9",
             "filesize": 7602176,
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
@@ -42,10 +49,17 @@
     ],
     "versions": [
         {
+            "name": "5.5.3",
+            "images": {
+                "hda_disk_image": "FWB_KVM-v500-build0730-FORTINET.out.kvm-boot.qcow2",
+                "hdb_disk_image": "FWB_KVM-v500-FORTINET.out.kvm-log.qcow2"
+            }
+        },
+        {
             "name": "5.5.2",
             "images": {
                 "hda_disk_image": "FWB_KVM-v500-build0723-FORTINET.out.kvm-boot.qcow2",
-                "hdb_disk_image": "FWB_KVM-v500-build0723-FORTINET.out.kvm-log.qcow2"
+                "hdb_disk_image": "FWB_KVM-v500-FORTINET.out.kvm-log.qcow2"
             }
         }
     ]

--- a/appliances/pfsense.gns3a
+++ b/appliances/pfsense.gns3a
@@ -46,6 +46,12 @@
     ],
     "versions": [
         {
+            "name": "2.3.1",
+            "images": {
+                "hda_disk_image": "pfSense-CE-2.3.1-RELEASE-2g-amd64-nanobsd.img"
+            }
+        },
+        {
             "name": "2.3",
             "images": {
                 "hda_disk_image": "pfSense-CE-2.3-RELEASE-2g-amd64-nanobsd.img"


### PR DESCRIPTION
The reason for changed lines is that FortiADC and FortiWeb use their data/log disks the same way we use the empty_xx_G.qcow2 ones: The same empty disk is re-used for all versions.