### PR TITLE
update ostinato to v0.8

### DIFF
--- a/appliances/ostinato.gns3a
+++ b/appliances/ostinato.gns3a
@@ -25,6 +25,14 @@
     },
     "images": [
         {
+            "filename": "ostinato-0.8-1.qcow2",
+            "version": "0.8",
+            "md5sum": "12e990ba695103cfac82f8771b8015d4",
+            "filesize": 57344000,
+            "download_url": "http://www.bernhard-ehlers.de/projects/ostinato4gns3/index.html",
+            "direct_download_url": "http://www.bernhard-ehlers.de/projects/ostinato4gns3/ostinato-0.8-1.qcow2"
+        },
+        {
             "filename": "ostinato-0.7.1-3.qcow2",
             "version": "0.7.1",
             "md5sum": "d1b1173ab4ad12b3b4e34c3b078dcd9e",
@@ -34,6 +42,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "0.8",
+            "images": {
+                "hda_disk_image": "ostinato-0.8-1.qcow2"
+            }
+        },
         {
             "name": "0.7.1",
             "images": {

--- a/packer/tinycore-linux/scripts/ostinato-drone.sh
+++ b/packer/tinycore-linux/scripts/ostinato-drone.sh
@@ -52,28 +52,9 @@ ver=`curl -sI https://bintray.com/pstavirs/ostinato/ostinato-src/_latestVersion 
 curl -k -L -O https://bintray.com/artifact/download/pstavirs/ostinato/ostinato-src-$ver.tar.gz
 tar xfz ostinato-src-$ver.tar.gz
 cd ostinato-$ver
-# patch only useful for ostinato <= 0.7.1
-patch -p0 <<'EOF'
---- server/pcapport.cpp.orig	2015-02-24 08:38:33.000000000 +0000
-+++ server/pcapport.cpp	2015-02-25 09:58:38.943383048 +0000
-@@ -696,7 +696,8 @@
- 
-     while (curTicks.QuadPart < tgtTicks.QuadPart)
-         QueryPerformanceCounter(&curTicks);
--#elif defined(Q_OS_LINUX)
-+// #elif defined(Q_OS_LINUX)
-+#elif 0
-     struct timeval delay, target, now;
- 
-     //qDebug("usec delay = %ld", usec);
-EOF
 qmake -config release "QMAKE_CXXFLAGS+=$CXXFLAGS"
-# ostinato >= 0.8 supports building of a component
-# make server
-# sudo INSTALL_ROOT=/tmp/ostinato make server-install_subtargets
-make
-sudo INSTALL_ROOT=/tmp/ostinato make install
-sudo rm /tmp/ostinato/usr/local/bin/ostinato
+make server
+sudo INSTALL_ROOT=/tmp/ostinato make server-install_subtargets
 sudo chown -R root:root /tmp/ostinato
 sudo chmod +s /tmp/ostinato/usr/local/bin/drone
 cd ..
@@ -120,6 +101,7 @@ if grep -q -w nodhcp /proc/cmdline; then
 	# activate other eth devices
 	NETDEVICES="$(awk -F: '/eth[1-9][0-9]*:/{print $1}' /proc/net/dev 2>/dev/null)"
 	for DEVICE in $NETDEVICES; do
+		sysctl -q -w net.ipv6.conf.$DEVICE.disable_ipv6=1
 		ifconfig $DEVICE mtu 9000 up
 	done
 fi

--- a/packer/tinycore-linux/scripts/ostinato.sh
+++ b/packer/tinycore-linux/scripts/ostinato.sh
@@ -42,21 +42,6 @@ ver=`curl -sI https://bintray.com/pstavirs/ostinato/ostinato-src/_latestVersion 
 curl -k -L -O https://bintray.com/artifact/download/pstavirs/ostinato/ostinato-src-$ver.tar.gz
 tar xfz ostinato-src-$ver.tar.gz
 cd ostinato-$ver
-# patch only useful for ostinato <= 0.7.1
-patch -p0 <<'EOF'
---- server/pcapport.cpp.orig	2015-02-24 08:38:33.000000000 +0000
-+++ server/pcapport.cpp	2015-02-25 09:58:38.943383048 +0000
-@@ -696,7 +696,8 @@
- 
-     while (curTicks.QuadPart < tgtTicks.QuadPart)
-         QueryPerformanceCounter(&curTicks);
--#elif defined(Q_OS_LINUX)
-+// #elif defined(Q_OS_LINUX)
-+#elif 0
-     struct timeval delay, target, now;
- 
-     //qDebug("usec delay = %ld", usec);
-EOF
 qmake -config release "QMAKE_CXXFLAGS+=$CXXFLAGS"
 make
 sudo INSTALL_ROOT=/tmp/ostinato make install
@@ -120,6 +105,7 @@ if grep -q -w nodhcp /proc/cmdline; then
 	# activate other eth devices
 	NETDEVICES="$(awk -F: '/eth[1-9][0-9]*:/{print $1}' /proc/net/dev 2>/dev/null)"
 	for DEVICE in $NETDEVICES; do
+		sysctl -q -w net.ipv6.conf.$DEVICE.disable_ipv6=1
 		ifconfig $DEVICE mtu 9000 up
 	done
 fi


### PR DESCRIPTION
Nothing special, only ostinato is updated.

Still uses the old tinycore 6.4. I thought about v7.x, but decided against:
- only few changes compared to 6.x, mainly newer kernel
- current version is 7.1, which has an URL, which will change with release 7.2. The latest release with a stable URL is 7.0 and I don't like using a .0 release.