### PR TITLE
Additional tools (curl, host, mtr, socat) for ipterm/webterm, add READMEs

### DIFF
--- a/docker/ipterm/README.md
+++ b/docker/ipterm/README.md
@@ -5,7 +5,11 @@ This appliance contains the following networking tools:
 - net-tools (basic network administration tools)
 - iproute2 (advanced network administration tools)
 - ping and traceroute
+- curl (data transfer utility)
+- host (DNS lookup utility)
 - iperf3
+- mtr (full screen traceroute)
+- socat (utility for reading/writing from/to network connections)
 - ssh client
 - tcpdump
 - telnet

--- a/docker/ipterm/base/Dockerfile
+++ b/docker/ipterm/base/Dockerfile
@@ -25,5 +25,5 @@ RUN set -ex \
 # install remaining tools
 #
     && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
-        net-tools tcpdump telnet traceroute iperf3 openssh-client vim-tiny \
+        net-tools tcpdump telnet traceroute curl iperf3 knot-host openssh-client mtr-tiny socat nano vim-tiny \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/ipterm/base/README.md
+++ b/docker/ipterm/base/README.md
@@ -1,0 +1,26 @@
+# ipterm-base - Networking Toolbox, base image
+
+This is a base image, it's not intended for direct use.
+
+This image contains the following networking tools:
+
+- net-tools (basic network administration tools)
+- iproute2 (advanced network administration tools)
+- ping and traceroute
+- curl (data transfer utility)
+- host (DNS lookup utility)
+- iperf3
+- mtr (full screen traceroute)
+- socat (utility for reading/writing from/to network connections)
+- ssh client
+- tcpdump
+- telnet
+- mtools (multicast tools msend & mreceive),
+  see https://github.com/troglobit/mtools
+
+## Build and publish the Image
+
+```
+docker build -t gns3/ipterm-base .
+docker push gns3/ipterm-base    (optional)
+```

--- a/docker/ipterm/cli/README.md
+++ b/docker/ipterm/cli/README.md
@@ -1,0 +1,29 @@
+# ipterm - Networking Toolbox, CLI version
+
+Based on ipterm-base it sets bash as the default command and
+uses /root as a persistent directory.
+
+This appliance contains the following networking tools:
+
+- net-tools (basic network administration tools)
+- iproute2 (advanced network administration tools)
+- ping and traceroute
+- curl (data transfer utility)
+- host (DNS lookup utility)
+- iperf3
+- mtr (full screen traceroute)
+- socat (utility for reading/writing from/to network connections)
+- ssh client
+- tcpdump
+- telnet
+- mtools (multicast tools msend & mreceive),
+  see https://github.com/troglobit/mtools
+
+## Build and publish the Image
+
+Before ipterm-base has to be build.
+
+```
+docker build -t gns3/ipterm .
+docker push gns3/ipterm
+```

--- a/docker/ipterm/web/Dockerfile
+++ b/docker/ipterm/web/Dockerfile
@@ -3,7 +3,7 @@
 FROM gns3/ipterm-base
 
 # minimal init, see https://github.com/Yelp/dumb-init
-ADD https://github.com/Yelp/dumb-init/releases/download/v1.1.0/dumb-init_1.1.0_amd64 /usr/local/sbin/dumb-init
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.1.1/dumb-init_1.1.1_amd64 /usr/local/sbin/dumb-init
 
 RUN set -ex \
     && chmod 755 /usr/local/sbin/dumb-init \
@@ -12,7 +12,7 @@ RUN set -ex \
 # install web tools
 #
     && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
-        firefox-esr lxterminal jwm menu \
+        firefox-esr lxterminal jwm menu leafpad \
     && rm -rf /var/lib/apt/lists/* \
     && /bin/echo -e '\
 \x23!/bin/sh\n\
@@ -27,9 +27,9 @@ status=$?\n\
 \n\
 \x23 workaround: restart firefox, if it crashes during initialization\n\
 if [ $status -eq 139 -a $(($(date +%s)-start)) -le 10 ]; then\n\
-        firefox $start_url\n\
+	firefox $start_url\n\
 fi' \
-        > /usr/local/bin/start-firefox; chmod +x /usr/local/bin/start-firefox \
+        > /usr/local/bin/start-firefox && chmod +x /usr/local/bin/start-firefox \
     && /bin/echo -e '\
 ?package(firefox-esr):\\\n\
  needs="x11"\\\n\
@@ -48,12 +48,13 @@ fgcolor=#ffffff' \
         > /root/.config/lxterminal/lxterminal.conf \
     && /bin/echo -e '\
 \x23!/bin/sh\n\
+[ $$ -eq 1 ] && exec dumb-init "$0" "$@"\n\
 \n\
 cd\n\
 export SHELL=/bin/bash\n\
 start-firefox &\n\
 jwm' \
-        > /start_browser.sh; chmod +x /start_browser.sh
+        > /etc/init.sh && chmod +x /etc/init.sh
 
 VOLUME [ "/root" ]
-CMD [ "dumb-init", "/start_browser.sh" ]
+CMD [ "/etc/init.sh" ]

--- a/docker/ipterm/web/README.md
+++ b/docker/ipterm/web/README.md
@@ -1,0 +1,30 @@
+# webterm - Networking Toolbox, Web/GUI version
+
+This image adds the Firefox web browser to ipterm-base.
+Like ipterm, the /root directory is persistent.
+
+This appliance contains the following networking tools:
+
+- Firefox web browser
+- net-tools (basic network administration tools)
+- iproute2 (advanced network administration tools)
+- ping and traceroute
+- curl (data transfer utility)
+- host (DNS lookup utility)
+- iperf3
+- mtr (full screen traceroute)
+- socat (utility for reading/writing from/to network connections)
+- ssh client
+- tcpdump
+- telnet
+- mtools (multicast tools msend & mreceive),
+  see https://github.com/troglobit/mtools
+
+## Build and publish the Images
+
+Before ipterm-base has to be build.
+
+```
+docker build -t gns3/webterm .
+docker push gns3/webterm
+```


### PR DESCRIPTION
Added some toole (curl, host, mtr and socat).

Added READMEs in the subdirectories. This should solve the issue, that the images in docker hub have no reasonable full description.