### PR TITLE
Updated cisco-asav appliance

### DIFF
--- a/appliances/cisco-asav.gns3a
+++ b/appliances/cisco-asav.gns3a
@@ -24,6 +24,27 @@
         "kvm": "require"
     },
     "images": [
+       {
+            "filename": "asav971.qcow2",
+            "version": "9.7.1",
+            "md5sum": "cb31f53e70a9e409829d2f832ff09191",
+            "filesize": 199688192,
+            "download_url": "https://software.cisco.com/download/release.html?mdfid=286119613&flowid=&softwareid=280775065&release=9.7.1&relind=AVAILABLE&rellifecycle=&reltype=latest"
+        },
+        {
+            "filename": "asav962.qcow2",
+            "version": "9.6.2",
+            "md5sum": "a4c892afe610776dde8a176f1049ae96",
+            "filesize": 177274880,
+            "download_url": "https://software.cisco.com/download/release.html?mdfid=286119613&flowid=&softwareid=280775065&release=9.6.2&relind=AVAILABLE&rellifecycle=&reltype=latest"
+        },
+        {
+            "filename": "asav961.qcow2",
+            "version": "9.6.1",
+            "md5sum": "c8726827cb72f4eed8cb52a64bca091c",
+            "filesize": 173801472,
+            "download_url": "https://software.cisco.com/download/release.html?mdfid=286119613&flowid=&softwareid=280775065&release=9.6.1&relind=AVAILABLE&rellifecycle=&reltype=latest"
+        },
         {
             "filename": "asav952-204.qcow2",
             "version": "9.5.2-204",
@@ -37,9 +58,27 @@
             "md5sum": "ca071370278ecbd5dfdb1c5a4161571a",
             "filesize": 160038912,
             "download_url": "https://virl.mediuscorp.com/my-account/"
-        }
+        }  
     ],
     "versions": [
+         {
+            "name": "9.7.1",
+            "images": {
+                "hda_disk_image": "asav971.qcow2"
+            }
+        },
+        {
+            "name": "9.6.2",
+            "images": {
+                "hda_disk_image": "asav962.qcow2"
+            }
+        }, 
+        {
+            "name": "9.6.1",
+            "images": {
+                "hda_disk_image": "asav961.qcow2"
+            }
+        },
         {
             "name": "9.5.2-204",
             "images": {
@@ -54,3 +93,4 @@
         }
     ]
 }
+


### PR DESCRIPTION
Updated to support ASAv versions 9.7.1, 9.6.2, and 9.6.1