### PR TITLE
Update Ostinato to v0.8, commit 97c7d79

### DIFF
--- a/appliances/ostinato.gns3a
+++ b/appliances/ostinato.gns3a
@@ -25,6 +25,14 @@
     },
     "images": [
         {
+            "filename": "ostinato-0.8-97c7d79.qcow2",
+            "version": "0.8-97c7d79",
+            "md5sum": "5aad15c1eb7baac588a4c8c3faafa380",
+            "filesize": 98631680,
+            "download_url": "http://www.bernhard-ehlers.de/projects/ostinato4gns3/index.html",
+            "direct_download_url": "http://www.bernhard-ehlers.de/projects/ostinato4gns3/ostinato-0.8-97c7d79.qcow2"
+        },
+        {
             "filename": "ostinato-0.8-1.qcow2",
             "version": "0.8",
             "md5sum": "12e990ba695103cfac82f8771b8015d4",
@@ -34,6 +42,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "0.8-97c7d79",
+            "images": {
+                "hda_disk_image": "ostinato-0.8-97c7d79.qcow2"
+            }
+        },
         {
             "name": "0.8",
             "images": {

--- a/packer/tinycore-linux/ostinato.json
+++ b/packer/tinycore-linux/ostinato.json
@@ -1,4 +1,6 @@
 {
+    "tc_iso_url": "http://distro.ibiblio.org/tinycorelinux/7.x/x86/archive/7.2/Core-7.2.iso",
+    "tc_iso_checksum": "77bf8cceacd2110120451f3f22f85156",
     "vm_name": "ostinato.qcow2",
     "setup_script": "ostinato.sh",
     "disk_size": "200"

--- a/packer/tinycore-linux/scripts/ostinato-drone.sh
+++ b/packer/tinycore-linux/scripts/ostinato-drone.sh
@@ -54,7 +54,7 @@ tce-load -wi libpcap-dev
 tce-load -wi git
 git clone https://github.com/pstavirs/ostinato.git
 cd ostinato
-[ -n "$git-commit" ] && git checkout "$git_commit"
+[ -n "$git_commit" ] && git checkout "$git_commit"
 qmake -config release "QMAKE_CXXFLAGS+=$CXXFLAGS"
 make server
 sudo INSTALL_ROOT=/tmp/ostinato make server-install_subtargets

--- a/packer/tinycore-linux/scripts/ostinato-drone.sh
+++ b/packer/tinycore-linux/scripts/ostinato-drone.sh
@@ -1,6 +1,9 @@
 set -e
 set -x
 
+# git branch, commit or tag
+git_commit=97c7d79
+
 # setup environment
 . /etc/profile
 . /etc/init.d/tc-functions
@@ -48,10 +51,10 @@ rm -rf protobuf*
 # compile ostinato
 tce-load -wi qt-4.x-dev
 tce-load -wi libpcap-dev
-ver=`curl -sI https://bintray.com/pstavirs/ostinato/ostinato-src/_latestVersion | sed -n '/Location:/ {s%.*/ostinato-src/%%;s%/view.*%%;p;}'`
-curl -k -L -O https://bintray.com/artifact/download/pstavirs/ostinato/ostinato-src-$ver.tar.gz
-tar xfz ostinato-src-$ver.tar.gz
-cd ostinato-$ver
+tce-load -wi git
+git clone https://github.com/pstavirs/ostinato.git
+cd ostinato
+[ -n "$git-commit" ] && git checkout "$git_commit"
 qmake -config release "QMAKE_CXXFLAGS+=$CXXFLAGS"
 make server
 sudo INSTALL_ROOT=/tmp/ostinato make server-install_subtargets
@@ -97,6 +100,7 @@ if grep -q -w nodhcp /proc/cmdline; then
 	# alternatively configure static interface address and route
 	#ifconfig eth0 x.x.x.x netmask 255.255.255.0 up
 	#route add default gw y.y.y.y
+	#echo 'nameserver z.z.z.z' > /etc/resolv.conf
 
 	# activate other eth devices
 	NETDEVICES="$(awk -F: '/eth[1-9][0-9]*:/{print $1}' /proc/net/dev 2>/dev/null)"

--- a/packer/tinycore-linux/scripts/ostinato.sh
+++ b/packer/tinycore-linux/scripts/ostinato.sh
@@ -44,7 +44,7 @@ tce-load -wi libpcap-dev
 tce-load -wi git
 git clone https://github.com/pstavirs/ostinato.git
 cd ostinato
-[ -n "$git-commit" ] && git checkout "$git_commit"
+[ -n "$git_commit" ] && git checkout "$git_commit"
 qmake -config release "QMAKE_CXXFLAGS+=$CXXFLAGS"
 make
 sudo INSTALL_ROOT=/tmp/ostinato make install

--- a/packer/tinycore-linux/scripts/ostinato.sh
+++ b/packer/tinycore-linux/scripts/ostinato.sh
@@ -1,6 +1,9 @@
 set -e
 set -x
 
+# git branch, commit or tag
+git_commit=97c7d79
+
 # setup environment
 . /etc/profile
 
@@ -38,10 +41,10 @@ rm -rf protobuf*
 # compile ostinato
 tce-load -wi qt-4.x-dev
 tce-load -wi libpcap-dev
-ver=`curl -sI https://bintray.com/pstavirs/ostinato/ostinato-src/_latestVersion | sed -n '/Location:/ {s%.*/ostinato-src/%%;s%/view.*%%;p;}'`
-curl -k -L -O https://bintray.com/artifact/download/pstavirs/ostinato/ostinato-src-$ver.tar.gz
-tar xfz ostinato-src-$ver.tar.gz
-cd ostinato-$ver
+tce-load -wi git
+git clone https://github.com/pstavirs/ostinato.git
+cd ostinato
+[ -n "$git-commit" ] && git checkout "$git_commit"
 qmake -config release "QMAKE_CXXFLAGS+=$CXXFLAGS"
 make
 sudo INSTALL_ROOT=/tmp/ostinato make install
@@ -79,10 +82,21 @@ RateAccuracy=Low
 Include=eth*
 Exclude=eth0
 EOF
+cat > .config/Ostinato/Ostinato.conf <<'EOF'
+[General]
+WiresharkPath=/usr/local/bin/wireshark-gtk
+TsharkPath=/usr/local/bin/tshark
+GzipPath=/bin/gzip
+DiffPath=/usr/bin/diff
+AwkPath=/usr/bin/awk
+EOF
 
 # change tcedir back to hard disk
 rm -f /etc/sysconfig/tcedir
 mv /etc/sysconfig/tcedir.hd /etc/sysconfig/tcedir
+
+# install wireshark
+tce-load -wi wireshark adwaita-icon-theme
 
 # disable automatic interface configuration with dhcp
 sudo sed -i -e '/label .*core/,/append / s/\(append .*\)/\1 nodhcp/' /mnt/sda1/boot/extlinux/extlinux.conf
@@ -101,6 +115,7 @@ if grep -q -w nodhcp /proc/cmdline; then
 	# alternatively configure static interface address and route
 	#ifconfig eth0 x.x.x.x netmask 255.255.255.0 up
 	#route add default gw y.y.y.y
+	#echo 'nameserver z.z.z.z' > /etc/resolv.conf
 
 	# activate other eth devices
 	NETDEVICES="$(awk -F: '/eth[1-9][0-9]*:/{print $1}' /proc/net/dev 2>/dev/null)"

--- a/packer/tinycore-linux/scripts/packages.sh
+++ b/packer/tinycore-linux/scripts/packages.sh
@@ -8,7 +8,7 @@ ln -s /mnt/sda1/tce /etc/sysconfig/tcedir
 rm -rf /usr/local/tce.installed/*
 
 tce-load -wi ipv6-`uname -r` iptables iproute2
-
+tce-load -wi nano
 
 echo "modprobe ipv6" >> /opt/bootlocal.sh
 echo "sysctl -w net.ipv4.ip_forward=1" >> /opt/bootlocal.sh


### PR DESCRIPTION
Add Wireshark to VM
Update TinyCore Linux to v7.2

I had to update TinyCore Linux to 7.2, as the old TinyCore 6.4 doesn't contain the wireshark package. I didn't change to TC 7.2 globally, only for the Ostinato VM. The use of 7.2 was painless, only very few packages have been renamed/deleted. So updating the other VMs should be easy. One exception is the firefox VM as the package firefox-official was removed, maybe firefox-ESR or firefox_getlatest can be used.

I added nano to the list of always installed packages, as not everyone like vi.