### PR TITLE
update arista template with the latest arista vEOS version 4.18.1F.

### DIFF
--- a/appliances/arista-veos.gns3a
+++ b/appliances/arista-veos.gns3a
@@ -25,10 +25,10 @@
     },
     "images": [
         {
-            "filename": "vEOS-lab-4.18.0.vmdk",
-            "version": "4.18.0",
-            "md5sum": "4aac678baa475c89ddb2e4c516c423cb",
-            "filesize": 293666816,
+            "filename": "vEOS-lab-4.18.1F.vmdk",
+            "version": "4.18.1F",
+            "md5sum": "9648c63185f3b793b47528a858ca4364",
+            "filesize": 620625920,
             "download_url": "https://www.arista.com/en/support/software-download"
         },
         {
@@ -83,10 +83,10 @@
     ],
     "versions": [
         {
-            "name": "4.18.0",
+            "name": "4.18.1F",
             "images": {
                 "hda_disk_image": "Aboot-veos-serial-8.0.0.iso",
-                "hdb_disk_image": "vEOS-lab-4.18.0.vmdk"
+                "hdb_disk_image": "vEOS-lab-4.18.1F.vmdk"
             }
         },
         {


### PR DESCRIPTION
vEOS-lab-4.18.0.vmdk does not exist on the vEOS download page. it was changed to vEOS-lab-4.18.1F.vmdk