### PR TITLE
Enforce registry version 3 or 4

### DIFF
--- a/appliances/pan-vm-fw.gns3a
+++ b/appliances/pan-vm-fw.gns3a
@@ -7,7 +7,7 @@
     "documentation_url": "https://www.paloaltonetworks.com/documentation/80/virtualization/virtualization",
     "product_name": "PAN VM-Series Firewall",
     "product_url": "https://www.paloaltonetworks.com/products/secure-the-network/virtualized-next-generation-firewall/vm-series",
-    "registry_version": 1,
+    "registry_version": 3,
     "status": "experimental",
     "maintainer": "Community",
     "maintainer_email": "",
@@ -16,14 +16,14 @@
     "first_port_name": "management",
     "port_name_format": "ethernet1/{port1}",
     "qemu": {
-        "cpus": 2,
         "adapter_type": "virtio-net-pci",
         "adapters": 25,
         "ram": 4096,
         "arch": "x86_64",
         "console_type": "telnet",
         "hda_disk_interface": "virtio",
-        "kvm": "require"
+        "kvm": "require",
+        "options": "-smp 2"
     },
     "images": [
        {

--- a/check.py
+++ b/check.py
@@ -49,7 +49,6 @@ def check_appliance(appliance):
                 # The appliance require the schema V4
                 pass
         else:
-            return
             print('Schema version {} is not supported'.format(appliance_json['registry_version']))
             sys.exit(1)
 


### PR DESCRIPTION
Updated check.py to complain, when an invalid registry version is used, fixed pan-vm-fw.gns3a.

Otherwise PR https://github.com/GNS3/gns3-registry/pull/232 has only a temporary effect.

