### PR TITLE
Add 15.2d version to IOU L2 appliance

### DIFF
--- a/appliances/cisco-iou-l2.gns3a
+++ b/appliances/cisco-iou-l2.gns3a
@@ -28,6 +28,12 @@
             "version": "15.1a",
             "md5sum": "9549a20a7391fb849da32caa77a0d254",
             "filesize": 72726092
+        },
+        {
+            "filename": "i86bi-linux-l2-adventerprisek9-15.2d.bin",
+            "version": "15.2d",
+            "md5sum": "f16db44433beb3e8c828db5ddad1de8a",
+            "filesize": 105036380
         }
     ],
     "versions": [
@@ -42,6 +48,12 @@
             "images": {
                 "image": "i86bi-linux-l2-adventerprisek9-15.1a.bin"
             }
+        },
+        {
+            "filename": "i86bi-linux-l2-adventerprisek9-15.2d.bin",
+            "version": "15.2d",
+            "md5sum": "f16db44433beb3e8c828db5ddad1de8a",
+            "filesize": 105036380
         }
     ]
 }

--- a/appliances/cisco-iou-l2.gns3a
+++ b/appliances/cisco-iou-l2.gns3a
@@ -50,10 +50,10 @@
             }
         },
         {
-            "filename": "i86bi-linux-l2-adventerprisek9-15.2d.bin",
-            "version": "15.2d",
-            "md5sum": "f16db44433beb3e8c828db5ddad1de8a",
-            "filesize": 105036380
+            "name": "15.2d",
+            "images": {
+                "image": "i86bi-linux-l2-adventerprisek9-15.2d.bin"
+            }
         }
     ]
 }


### PR DESCRIPTION
This version of IOU supports Private-VLAN, L3 EthChannel and VACLs.