### PR TITLE
New Cumulus VX release

### DIFF
--- a/appliances/cumulus-vx.gns3a
+++ b/appliances/cumulus-vx.gns3a
@@ -13,7 +13,7 @@
     "maintainer_email": "developers@gns3.net",
     "usage": "Default username is cumulus and password is CumulusLinux!",
     "first_port_name": "eth0",
-    "port_name_format": "swp{0}",
+    "port_name_format": "swp{port1}",
     "qemu": {
         "adapter_type": "virtio-net-pci",
         "adapters": 7,

--- a/appliances/cumulus-vx.gns3a
+++ b/appliances/cumulus-vx.gns3a
@@ -24,6 +24,13 @@
     },
     "images": [
         {
+            "filename": "cumulus-linux-3.4.2-vx-amd64.qcow2",
+            "version": "3.4.2",
+            "md5sum": "ca844684784ceeee893d0cd76dc44e3b",
+            "filesize": 1060700160,
+            "download_url": "https://cumulusnetworks.com/cumulus-vx/download/"
+        },
+        {
             "filename": "cumulus-linux-3.4.1-vx-amd64.qcow2",
             "version": "3.4.1",
             "md5sum": "38319aa04533d91b1121a02f6ed99993",
@@ -109,6 +116,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "3.4.2",
+            "images": {
+                "hda_disk_image": "cumulus-linux-3.4.2-vx-amd64.qcow2"
+            }
+        },
         {
             "name": "3.4.1",
             "images": {


### PR DESCRIPTION
Add Cumulus VX 3.4.2 release and fix interface numbering (should start from swp1, not swp0).