### PR TITLE
[gns3/haproxy]: Add stats section to the default configuration

### DIFF
--- a/docker/haproxy/haproxy.cfg
+++ b/docker/haproxy/haproxy.cfg
@@ -44,3 +44,12 @@ backend app
     server  app1 192.168.41.1:80 check
     server  app2 192.168.41.2:80 check
     server  app3 192.168.41.3:80 check
+
+#---------------------------------------------------------------------
+# Monitoring stats
+#---------------------------------------------------------------------
+listen stats 
+ bind *:1234
+ stats enable
+ stats uri /
+ stats hide-version


### PR DESCRIPTION
The statistics configuration section is added to haproxy default config file. 
Beginner users will only have to configure backend server to get a working haproxy.