### PR TITLE
Update Ostinato to v0.9

### DIFF
--- a/appliances/ostinato.gns3a
+++ b/appliances/ostinato.gns3a
@@ -25,12 +25,12 @@
     },
     "images": [
         {
-            "filename": "ostinato-0.8-97c7d79.qcow2",
-            "version": "0.8-97c7d79",
-            "md5sum": "5aad15c1eb7baac588a4c8c3faafa380",
-            "filesize": 98631680,
+            "filename": "ostinato-0.9-1.qcow2",
+            "version": "0.9",
+            "md5sum": "00b4856ec9fffbcbcab7a8f757355d69",
+            "filesize": 101646336,
             "download_url": "http://www.bernhard-ehlers.de/projects/ostinato4gns3/index.html",
-            "direct_download_url": "http://www.bernhard-ehlers.de/projects/ostinato4gns3/ostinato-0.8-97c7d79.qcow2"
+            "direct_download_url": "http://www.bernhard-ehlers.de/projects/ostinato4gns3/ostinato-0.9-1.qcow2"
         },
         {
             "filename": "ostinato-0.8-1.qcow2",
@@ -43,9 +43,9 @@
     ],
     "versions": [
         {
-            "name": "0.8-97c7d79",
+            "name": "0.9",
             "images": {
-                "hda_disk_image": "ostinato-0.8-97c7d79.qcow2"
+                "hda_disk_image": "ostinato-0.9-1.qcow2"
             }
         },
         {

--- a/packer/tinycore-linux/ostinato.json
+++ b/packer/tinycore-linux/ostinato.json
@@ -1,6 +1,6 @@
 {
-    "tc_iso_url": "http://distro.ibiblio.org/tinycorelinux/7.x/x86/archive/7.2/Core-7.2.iso",
-    "tc_iso_checksum": "77bf8cceacd2110120451f3f22f85156",
+    "tc_iso_url": "http://distro.ibiblio.org/tinycorelinux/8.x/x86/archive/8.2/Core-8.2.iso",
+    "tc_iso_checksum": "560b6d9da10140f13f22eeea35bf6087",
     "vm_name": "ostinato.qcow2",
     "setup_script": "ostinato.sh",
     "disk_size": "200"

--- a/packer/tinycore-linux/scripts/gui.sh
+++ b/packer/tinycore-linux/scripts/gui.sh
@@ -1,6 +1,8 @@
 set -e
 set -x
 
+. /etc/init.d/tc-functions
+
 # Install the GUI
 tce-load -wi fltk-1.3
 tce-load -wi flwm
@@ -12,10 +14,15 @@ tce-load -wi Xorg-7.7
 # Create xorg-setup-tools
 tce-load -wi Xdialog
 
-. /etc/init.d/tc-functions
-getMirror
-wget -P /tmp $MIRROR/squashfs-tools.tcz
-tce-load -i /tmp/squashfs-tools.tcz
+# install squashfs-tools only in RAM
+mv /etc/sysconfig/tcedir /etc/sysconfig/tcedir.hd
+ln -s /tmp/tce /etc/sysconfig/tcedir
+sudo cp -a /usr/local/tce.installed /usr/local/tce.installed.hd
+tce-load -wi squashfs-tools.tcz
+rm -f /etc/sysconfig/tcedir
+mv /etc/sysconfig/tcedir.hd /etc/sysconfig/tcedir
+sudo rm -rf /usr/local/tce.installed
+sudo mv /usr/local/tce.installed.hd /usr/local/tce.installed
 
 sudo mkdir /tmp/xorg-setup-tools
 sudo mkdir -p /tmp/xorg-setup-tools/usr/local/bin
@@ -170,9 +177,10 @@ cat > setup_resolution <<'EOF'
 
 # available resolutions
 resolutions='
-1024x768 ""
-800x600 ""
 640x480 ""
+800x600 ""
+1024x768 ""
+1280x720 ""
 '
 
 # get resolution
@@ -229,7 +237,7 @@ cat > /usr/local/share/X11/xorg.conf.d/99-resolution.conf <<'EOF'
 Section "Screen"
     Identifier "Screen0"
     SubSection "Display"
-        Modes "800x600"
+        Modes "1024x768"
     EndSubSection
 EndSection
 EOF

--- a/packer/tinycore-linux/scripts/ostinato-drone.sh
+++ b/packer/tinycore-linux/scripts/ostinato-drone.sh
@@ -2,7 +2,7 @@ set -e
 set -x
 
 # git branch, commit or tag
-git_commit=97c7d79
+git_commit=v0.9
 
 # setup environment
 . /etc/profile
@@ -28,6 +28,7 @@ tce-load -wi iperf3
 # change tcedir to ram disk
 mv /etc/sysconfig/tcedir /etc/sysconfig/tcedir.hd
 ln -s /tmp/tce /etc/sysconfig/tcedir
+sudo cp -a /usr/local/tce.installed /usr/local/tce.installed.hd
 
 # setup compile environment
 tce-load -wi compiletc
@@ -82,6 +83,8 @@ EOF
 # change tcedir back to hard disk
 rm -f /etc/sysconfig/tcedir
 mv /etc/sysconfig/tcedir.hd /etc/sysconfig/tcedir
+sudo rm -rf /usr/local/tce.installed
+sudo mv /usr/local/tce.installed.hd /usr/local/tce.installed
 
 # disable automatic interface configuration with dhcp
 sudo sed -i -e '/label .*core/,/append / s/\(append .*\)/\1 nodhcp/' /mnt/sda1/boot/extlinux/extlinux.conf
@@ -110,9 +113,12 @@ if grep -q -w nodhcp /proc/cmdline; then
 	done
 fi
 
+# disable ostinato update, makes no sense in this environment
+echo -e '# disable ostinato update\n127.0.0.127 update.ostinato.org' >> /etc/hosts
+
 # start ostinato drone
 sleep 2
-HOME=/home/gns3 drone < /dev/null > /var/log/ostinato-drone.log 2>&1 &
+su -c 'drone < /dev/null > /var/log/ostinato-drone.log 2>&1 &' gns3
 EOF
 
 exit 0

--- a/packer/tinycore-linux/scripts/ostinato.sh
+++ b/packer/tinycore-linux/scripts/ostinato.sh
@@ -2,7 +2,7 @@ set -e
 set -x
 
 # git branch, commit or tag
-git_commit=97c7d79
+git_commit=v0.9
 
 # setup environment
 . /etc/profile
@@ -18,6 +18,7 @@ tce-load -wi iperf3
 # change tcedir to ram disk
 mv /etc/sysconfig/tcedir /etc/sysconfig/tcedir.hd
 ln -s /tmp/tce /etc/sysconfig/tcedir
+sudo cp -a /usr/local/tce.installed /usr/local/tce.installed.hd
 
 # setup compile environment
 tce-load -wi compiletc
@@ -52,7 +53,7 @@ sudo mkdir -p /tmp/ostinato/usr/local/share/applications
 cat > ostinato.desktop <<'EOF'
 [Desktop Entry]
 Name=Ostinato
-Exec=ostinato
+Exec=ostinato > /var/log/ostinato.log 2>&1
 Type=Application
 X-FullPathIcon=/usr/local/share/pixmaps/ostinato_logo.png
 Icon=ostinato_logo.png
@@ -94,9 +95,17 @@ EOF
 # change tcedir back to hard disk
 rm -f /etc/sysconfig/tcedir
 mv /etc/sysconfig/tcedir.hd /etc/sysconfig/tcedir
+sudo rm -rf /usr/local/tce.installed
+sudo mv /usr/local/tce.installed.hd /usr/local/tce.installed
 
 # install wireshark
 tce-load -wi wireshark adwaita-icon-theme
+
+# install dillo (tiny web browser) for reading documentation
+tce-load -wi dillo ca-certificates
+echo -e '\nexport BROWSER=dillo' >> .ashrc
+sudo ln -s /usr/local/etc/ssl /etc/ssl
+echo 'etc/ssl' >> /opt/.filetool.lst
 
 # disable automatic interface configuration with dhcp
 sudo sed -i -e '/label .*core/,/append / s/\(append .*\)/\1 nodhcp/' /mnt/sda1/boot/extlinux/extlinux.conf
@@ -125,9 +134,12 @@ if grep -q -w nodhcp /proc/cmdline; then
 	done
 fi
 
+# disable ostinato update, makes no sense in this environment
+echo -e '# disable ostinato update\n127.0.0.127 update.ostinato.org' >> /etc/hosts
+
 # start ostinato drone
-sleep 2
-HOME=/home/gns3 drone < /dev/null > /var/log/ostinato-drone.log 2>&1 &
+#sleep 2
+#su -c 'drone < /dev/null > /var/log/ostinato-drone.log 2>&1 &' gns3
 EOF
 
 exit 0

--- a/packer/tinycore-linux/scripts/post_setup.sh
+++ b/packer/tinycore-linux/scripts/post_setup.sh
@@ -3,7 +3,7 @@ set -x
 
 # base system modifications
 sudo sed -i -e '/^\/opt\/bootlocal/ i' /opt/bootsync.sh
-echo -e "\nusername 'gns3', password 'gns3'\nRun filetool.sh -b if you want to save your changes" >> /etc/issue
+sudo sh -c 'echo -e "\nusername '"'"'gns3'"'"', password '"'"'gns3'"'"'\nRun filetool.sh -b if you want to save your changes" >> /etc/issue'
 echo 'etc/issue' >> /opt/.filetool.lst
 echo 'etc/shadow' >> /opt/.filetool.lst
 


### PR DESCRIPTION
Updated Ostinato to v0.9

I had to use TinyCore v8.2, as the previous used version 7.2 has issues with SSL certificates.

--

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filesnames in the "images" section are unique, to avoid appliances / version overwrinting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filesnames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*