### PR TITLE
New Sophos releases

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Before submitting a pull request, please check the following.
 ---
 When updating an **existing** appliance:
 - [ ] The new version is on top.
-- [ ] The filesnames in the "images" section are unique, to avoid appliances / version overwrinting each other.
+- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
 - [ ] If you forked the repo, running check.py doesn't drop any errors for the updated file.
 ---
 When creating a **new** appliance:
@@ -12,6 +12,6 @@ When creating a **new** appliance:
   - [ ] GNS3 VM can run it without any tweaks.
   - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
 - [ ] When adding a container: it builds on Docker Hub and can be pulled.
-- [ ] The filesnames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
+- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
 - [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
 - [ ] *Optional: a symbol has been created for the new appliance.*

--- a/appliances/sophos-utm.gns3a
+++ b/appliances/sophos-utm.gns3a
@@ -25,10 +25,24 @@
     },
     "images": [
         {
+            "filename": "asg-9.506-2.1.iso",
+            "version": "9.506-2.1",
+            "md5sum": "6b4374f8c5ee66ccdf9683f7349f59cb",
+            "filesize": 1006057472,
+            "download_url": "https://www.sophos.com/en-us/support/utm-downloads.aspx"
+        },
+        {
             "filename": "asg-9.500-9.1.iso",
             "version": "9.500-9.1",
             "md5sum": "8531349cdb7f07c94596b19f8e08081a",
             "filesize": 981612544,
+            "download_url": "https://www.sophos.com/en-us/support/utm-downloads.aspx"
+        },
+        {
+            "filename": "asg-9.415-1.1.iso",
+            "version": "9.415-1.1",
+            "md5sum": "505004bf5a5d5f2234b2056ec7b553d8",
+            "filesize": 961087488,
             "download_url": "https://www.sophos.com/en-us/support/utm-downloads.aspx"
         },
         {
@@ -126,10 +140,24 @@
     ],
     "versions": [
         {
+            "name": "9.506-2.1",
+            "images": {
+                "hda_disk_image": "empty30G.qcow2",
+                "cdrom_image": "asg-9.506-2.1.iso"
+            }
+        },
+        {
             "name": "9.500-9.1",
             "images": {
                 "hda_disk_image": "empty30G.qcow2",
                 "cdrom_image": "asg-9.500-9.1.iso"
+            }
+        },
+        {
+            "name": "9.415-1.1",
+            "images": {
+                "hda_disk_image": "empty30G.qcow2",
+                "cdrom_image": "asg-9.415-1.1.iso"
             }
         },
         {

--- a/appliances/sophos-xg.gns3a
+++ b/appliances/sophos-xg.gns3a
@@ -24,6 +24,20 @@
     },
     "images": [
         {
+            "filename": "VI-SFOS_17.0.2_MR-2.KVM-116-PRIMARY.qcow2",
+            "version": "17.0.2 MR2",
+            "md5sum": "2555fa6dcdcecad02c9f02dcb1c0c5e5",
+            "filesize": 324599808,
+            "download_url": "https://secure2.sophos.com/en-us/products/next-gen-firewall/free-trial.aspx"
+        },
+        {
+            "filename": "VI-SFOS_17.0.2_MR-2.KVM-116-AUXILARY.qcow2",
+            "version": "16.05.1 MR1",
+            "md5sum": "c3ef795423dbfc01771348b0daa75125",
+            "filesize": 59441152,
+            "download_url": "https://secure2.sophos.com/en-us/products/next-gen-firewall/free-trial.aspx"
+        },
+        {
             "filename": "VI-SFOS_16.05.4_MR-4.KVM-215-PRIMARY.qcow2",
             "version": "16.05.4 MR4",
             "md5sum": "20535c9e624f42e1977f1e407fbc565e",
@@ -95,6 +109,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "17.0.2 MR2",
+            "images": {
+                "hda_disk_image": "VI-SFOS_17.0.2_MR-2.KVM-116-PRIMARY.qcow2",
+                "hdb_disk_image": "VI-SFOS_17.0.2_MR-2.KVM-116-AUXILARY.qcow2"
+            }
+        },
         {
             "name": "16.05.4 MR4",
             "images": {


### PR DESCRIPTION
- [X] The new version is on top.
- [X] The filesnames in the "images" section are unique, to avoid appliances / version overwrinting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.