### PR TITLE
New VyOS release

### DIFF
--- a/appliances/vyos.gns3a
+++ b/appliances/vyos.gns3a
@@ -32,28 +32,36 @@
             "direct_download_url": "http://dev.packages.vyos.net/iso/preview/1.2.0-beta1/vyos-1.2.0-beta1-amd64.iso"
         },
         {
+            "filename": "vyos-1.1.8-amd64.iso",
+            "version": "1.1.8",
+            "md5sum": "95a141d4b592b81c803cdf7e9b11d8ea",
+            "filesize": 241172480,
+            "download_url": "https://downloads.vyos.io/?dir=release/1.1.8",
+            "direct_download_url": "https://downloads.vyos.io/release/1.1.8/vyos-1.1.8-amd64.iso"
+        },
+        {
             "filename": "vyos-1.1.7-amd64.iso",
             "version": "1.1.7",
             "md5sum": "9a7f745a0b0db0d4f1d9eee2a437fb54",
             "filesize": 245366784,
-            "download_url": "http://mirror.vyos.net/iso/release/1.1.7/",
-            "direct_download_url": "http://mirror.vyos.net/iso/release/1.1.7/vyos-1.1.7-amd64.iso"
+            "download_url": "https://downloads.vyos.io/?dir=release/1.1.7/",
+            "direct_download_url": "https://downloads.vyos.io/release/1.1.7/vyos-1.1.7-amd64.iso"
         },
         {
             "filename": "vyos-1.1.6-amd64.iso",
             "version": "1.1.6",
             "md5sum": "3128954d026e567402a924c2424ce2bf",
             "filesize": 245366784,
-            "download_url": "http://mirror.vyos.net/iso/release/1.1.6/",
-            "direct_download_url": "http://mirror.vyos.net/iso/release/1.1.6/vyos-1.1.6-amd64.iso"
+            "download_url": "hhttps://downloads.vyos.io/?dir=release/1.1.6/",
+            "direct_download_url": "https://downloads.vyos.io/release/1.1.6/vyos-1.1.6-amd64.iso"
         },
         {
             "filename": "vyos-1.1.5-amd64.iso",
             "version": "1.1.5",
             "md5sum": "193179532011ceaa87ee725bd8f22022",
             "filesize": 247463936,
-            "download_url": "http://mirror.vyos.net/iso/release/1.1.5/",
-            "direct_download_url": "http://mirror.vyos.net/iso/release/1.1.5/vyos-1.1.5-amd64.iso"
+            "download_url": "https://downloads.vyos.io/?dir=release/1.1.5/",
+            "direct_download_url": "https://downloads.vyos.io/release/1.1.5/vyos-1.1.5-amd64.iso"
         },
         {
             "filename": "empty8G.qcow2",


### PR DESCRIPTION
+fixed the download links for older releases.

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.