### PR TITLE
New vSRX releases

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@ When creating a **new** appliance:
 - It's tested locally, i.e.
   - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
   - [ ] GNS3 VM can run it without any tweaks.
+  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
   - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
 - [ ] When adding a container: it builds on Docker Hub and can be pulled.
 - [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).

--- a/appliances/juniper-vsrx.gns3a
+++ b/appliances/juniper-vsrx.gns3a
@@ -24,10 +24,24 @@
     },
     "images": [
         {
+            "filename": "media-vsrx-vmdisk-17.4R1.16.qcow2",
+            "version": "17.4R1",
+            "md5sum": "616c4742b09652318c73a7cc598468e7",
+            "filesize": 3965386752,
+            "download_url": "https://www.juniper.net/us/en/dm/free-vsrx-trial/"
+        },
+        {
             "filename": "media-vsrx-vmdisk-17.3R1.10.qcow2",
             "version": "17.3R1",
             "md5sum": "49b276e9ccdd8588f9e2ff38cccc884a",
             "filesize": 3782541312,
+            "download_url": "https://www.juniper.net/us/en/dm/free-vsrx-trial/"
+        },
+        {
+            "filename": "media-vsrx-vmdisk-15.1X49-D120.3.qcow2",
+            "version": "15.1X49-D120",
+            "md5sum": "02cf4df3dc988a407ccd5ddc30ee5385",
+            "filesize": 3280273408,
             "download_url": "https://www.juniper.net/us/en/dm/free-vsrx-trial/"
         },
         {
@@ -110,9 +124,21 @@
     ],
     "versions": [
         {
+            "name": "17.4R1",
+            "images": {
+                "hda_disk_image": "media-vsrx-vmdisk-17.4R1.16.qcow2"
+            }
+        },
+        {
             "name": "17.3R1",
             "images": {
                 "hda_disk_image": "media-vsrx-vmdisk-17.3R1.10.qcow2"
+            }
+        },
+        {
+            "name": "15.1X49-D120",
+            "images": {
+                "hda_disk_image": "media-vsrx-vmdisk-15.1X49-D120.3.qcow2"
             }
         },
         {


### PR DESCRIPTION
+added an extra check in the pull template for new appliances

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
