### PR TITLE
Add Cisco CSR 16.6.2, 16.7.1, vIOSL2 15.2 VIRL VMDK, Ubuntu 16.04.03

### DIFF
--- a/appliances/cisco-csr1000v.gns3a
+++ b/appliances/cisco-csr1000v.gns3a
@@ -25,23 +25,30 @@
         {
             "filename": "csr1000v-universalk9.16.07.01-serial.qcow2",
             "version": "16.7.1",
-            "md5sum": "13adbfc2586d06c9802b9805168c0c44",
-            "filesize": 882769920,
-            "download_url": "https://software.cisco.com/download/release.html?mdfid=284364978&flowid=39582&softwareid=282046477&release=Fuji-16.7.1&relind=AVAILABLE&rellifecycle=ED&reltype=latest"
+            "md5sum": "bad9000d4ae8317bbc99a34a8cdd2eb4",
+            "filesize": 884539392,
+            "download_url": "https://software.cisco.com/portal/pub/download/portal/select.html?&mdfid=284364978&flowid=39582&softwareid=282046477"
+        },
+        {
+            "filename": "csr1000v-universalk9.16.06.02-serial.qcow2",
+            "version": "16.6.2",
+            "md5sum": "11e393b31ab9d1ace8e5f7551c491ba2",
+            "filesize": 1570242560,
+            "download_url": "https://software.cisco.com/portal/pub/download/portal/select.html?&mdfid=284364978&flowid=39582&softwareid=282046477"
         },
         {
             "filename": "csr1000v-universalk9.16.06.01-serial.qcow2",
             "version": "16.6.1",
             "md5sum": "909e74446d3ff0b82c14327c0058fdc2",
             "filesize": 1566179328,
-            "download_url": "https://software.cisco.com/download/release.html?mdfid=284364978&flowid=39582&softwareid=282046477&release=Denali-16.3.5&relind=AVAILABLE&rellifecycle=ED&reltype=latest"
+            "download_url": "https://software.cisco.com/portal/pub/download/portal/select.html?&mdfid=284364978&flowid=39582&softwareid=282046477"
         },
         {
             "filename": "csr1000v-universalk9.16.05.02-serial.qcow2",
             "version": "16.5.2",
             "md5sum": "59a84da28d59ee75176aa05ecde7f72a",
             "filesize": 1322385408,
-            "download_url": "https://software.cisco.com/download/release.html?mdfid=284364978&flowid=39582&softwareid=282046477&release=Denali-16.3.5&relind=AVAILABLE&rellifecycle=ED&reltype=latest"
+            "download_url": "https://software.cisco.com/portal/pub/download/portal/select.html?&mdfid=284364978&flowid=39582&softwareid=282046477"
         },
         {
             "filename": "csr1000v-universalk9.16.5.1b-serial.qcow2",
@@ -91,6 +98,12 @@
             "name": "16.7.1",
             "images": {
                 "hda_disk_image": "csr1000v-universalk9.16.07.01-serial.qcow2"
+            }
+        },
+        {
+            "name": "16.6.2",
+            "images": {
+                "hda_disk_image": "csr1000v-universalk9.16.06.02-serial.qcow2"
             }
         },
         {

--- a/appliances/cisco-iosvl2.gns3a
+++ b/appliances/cisco-iosvl2.gns3a
@@ -24,6 +24,13 @@
     },
     "images": [
         {
+            "filename": "vios_l2-adventerprisek9-m.03.2017.vmdk",
+            "version": "15.2(20170321:233949)",
+            "md5sum": "3610c56ee8012d148c4b99225dc2d004",
+            "filesize": 97124352,
+            "download_url": "https://virl.mediuscorp.com/my-account/"
+        },
+        {
             "filename": "vios_l2-adventerprisek9-m.03.2017.qcow2",
             "version": "15.2(20170321:233949)",
             "md5sum": "8f14b50083a14688dec2fc791706bb3e",
@@ -39,6 +46,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "15.2(20170321:233949)",
+            "images": {
+                "hda_disk_image": "vios_l2-adventerprisek9-m.03.2017.vmdk"
+            }
+        },
         {
             "name": "15.2(20170321:233949)",
             "images": {

--- a/appliances/ubuntu-gui.gns3a
+++ b/appliances/ubuntu-gui.gns3a
@@ -45,6 +45,13 @@
             "md5sum": "45bccf63f2777e492f022dbf025f67d0",
             "filesize": 4302110720,
             "download_url": "http://www.osboxes.org/ubuntu/"
+        },
+        {
+            "filename": "ubuntu-16.04-server-cloudimg-amd64-disk1.img",
+            "version": "16.04.03",
+            "md5sum": "7e24f437418013d6600ac9f998a0e617",
+            "filesize": 290717696,
+            "download_url": "https://cloud-images.ubuntu.com/"
         }
     ],
     "versions": [
@@ -64,6 +71,12 @@
             "name": "16.04",
             "images": {
                 "hda_disk_image": "Ubuntu_16.04.3-VM-64bit.vmdk"
+            }
+        },
+        {
+            "name": "16.04.03",
+            "images": {
+                "hda_disk_image": "ubuntu-16.04-server-cloudimg-amd64-disk1.img"
             }
         }
     ]


### PR DESCRIPTION
Adding Cisco CSR 16.6.2, 16.7.1, vIOSL2 15.2 VIRL VMDK, Ubuntu 16.04.03

CSR 16.7.1 was already there but had incorrect md5 checksum and file size (do not coincide with file on cisco.com)

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.

