### PR TITLE
Add persistency to network automation containers (CLI & PyCharm) with additional mapping of /usr

### DIFF
--- a/docker/network_automation/Dockerfile
+++ b/docker/network_automation/Dockerfile
@@ -11,8 +11,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y --no-install-rec
     && rm -rf /var/lib/apt/lists/* \
     && pip install --upgrade pip \
     && pip install cryptography netmiko napalm pyntc \
-    && pip install --upgrade paramiko
+    && pip install --upgrade paramiko && mkdir /scripts
 
-VOLUME [ "/root" ]
+VOLUME [ "/root","/usr", "/scripts" ]
 CMD [ "sh", "-c", "cd; exec bash -i" ]
 

--- a/docker/network_automation_pycharm/Dockerfile
+++ b/docker/network_automation_pycharm/Dockerfile
@@ -53,4 +53,4 @@ ADD pycharm-run /etc/sv/pycharm/run
 RUN chmod a+x /etc/sv/pycharm/run
 RUN ln -s /etc/sv/pycharm /etc/service
 
-VOLUME /root /scripts
+VOLUME ["/root", "/usr/", "/scripts"]


### PR DESCRIPTION
From the community forum
https://gns3.com/qa/save-configuration-permanently-o

No persistence for network automation containers (CLI & PyCharm), hence the mapping of /usr directory.
Tested and packages persist GNS3 reboots as users can use /scripts for their own scripts.
-------

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ ] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
