### PR TITLE
Prompt for Schema file in new_appliance.py

### DIFF
--- a/new_appliance.py
+++ b/new_appliance.py
@@ -85,7 +85,11 @@ def ask_from_schema(schema):
     return data
 
 
-with open(os.path.join('schemas', 'appliance.json')) as f:
+current_dir = os.path.dirname(os.path.realpath(__file__))
+files = os.listdir('schemas')
+schema_name = ask_multiple('Schema filename', files)
+
+with open(os.path.join('schemas', schema_name)) as f:
     schema = json.load(f)
 
 


### PR DESCRIPTION
Fixes #309

Prompt the user for choosing between available schema file versions
```bash
$> ./new_appliance.py
Schema filename
1) appliance_v3.json
2) appliance_v5.json
3) appliance_v4.json
```