### PR TITLE
Fixed missing VyOS 1.1.8 entry

### DIFF
--- a/appliances/vyos.gns3a
+++ b/appliances/vyos.gns3a
@@ -81,6 +81,13 @@
             }
         },
         {
+            "name": "1.1.8",
+            "images": {
+                "hda_disk_image": "empty8G.qcow2",
+                "cdrom_image": "vyos-1.1.8-amd64.iso"
+            }
+        },
+        {
             "name": "1.1.7",
             "images": {
                 "hda_disk_image": "empty8G.qcow2",


### PR DESCRIPTION
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
