### PR TITLE
Update cisco-iosxrv9k.gns3a

### DIFF
--- a/appliances/cisco-iosxrv9k.gns3a
+++ b/appliances/cisco-iosxrv9k.gns3a
@@ -18,7 +18,7 @@
         "adapter_type": "e1000",
         "adapters": 4,
         "ram": 16384,
-        "arch": "i386",
+        "arch": "x86_64",
         "console_type": "telnet",
         "kvm": "require",
         "options": "-smp 4"


### PR DESCRIPTION
XRV 9000 series image requires the x86_64 qemu binary to address memory over 4gb, and also the appliance won't even boot using the i386 binary.

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ ] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
