### PR TITLE
Update cisco-ise.gns3a

### DIFF
--- a/appliances/cisco-ise.gns3a
+++ b/appliances/cisco-ise.gns3a
@@ -23,29 +23,36 @@
         "console_type": "vnc",
         "boot_priority": "cd",
         "kvm": "require",
-        "options": "-smp 2"
+        "options": "-smp 2 -smbios type=1,product=KVM"
     },
     "images": [
+        {
+            "filename": "ise-2.2.0.470.SPA.x86_64.iso",
+            "version": "2.2.0.470",
+            "md5sum": "7fe5e730d0a51ef66e69d1463717ff3f",
+            "filesize": 8044992512,
+            "download_url": "https://software.cisco.com/download/home/283801620/type/283802505/release/2.2.0"
+        },
         {
             "filename": "ise-2.1.0.474.SPA.x86_64.iso",
             "version": "2.1.0.474",
             "md5sum": "8dc844696790f2f5f37054899fab3e2a",
             "filesize": 6161475584,
-            "download_url": "https://software.cisco.com/download/release.html?mdfid=283801620&flowid=&softwareid=283802505&release=2.1.0&relind=AVAILABLE&rellifecycle=&reltype=latest"
+            "download_url": "https://software.cisco.com/download/home/283801620/type/283802505/release/2.1.0"
         },
         {
             "filename": "ise-2.0.1.130.SPA.x86_64.iso",
             "version": "2.0.1.130",
             "md5sum": "25ac842fdbb61f6e75f2f8b26beea28e",
             "filesize": 5129990144,
-            "download_url": "https://software.cisco.com/download/release.html?mdfid=283801620&flowid=&softwareid=283802505&release=2.1.0&relind=AVAILABLE&rellifecycle=&reltype=latest"
+            "download_url": "https://software.cisco.com/download/home/283801620/type/283802505/release/2.0.1"
         },
         {
             "filename": "ise-2.0.0.306.SPA.x86_64.iso",
             "version": "2.0.0.306",
             "md5sum": "b7a454ee235db29b5c208b19bfd1fbd1",
             "filesize": 5088827392,
-            "download_url": "https://software.cisco.com/download/release.html?mdfid=283801620&flowid=&softwareid=283802505&release=2.0.0&relind=AVAILABLE&rellifecycle=&reltype=latest"
+            "download_url": "https://software.cisco.com/download/home/283801620/type/283802505/release/2.0"
         },
         {
             "filename": "empty200G.qcow2",
@@ -57,6 +64,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "2.2.0.470",
+            "images": {
+                "hda_disk_image": "empty200G.qcow2",
+                "cdrom_image": "ise-2.2.0.470.SPA.x86_64.iso"
+            }
+        },
         {
             "name": "2.1.0.474",
             "images": {
@@ -78,6 +92,6 @@
                 "cdrom_image": "ise-2.0.0.306.SPA.x86_64.iso"
             }
         }
-      
+
     ]
 }

--- a/appliances/cisco-ise.gns3a
+++ b/appliances/cisco-ise.gns3a
@@ -92,6 +92,5 @@
                 "cdrom_image": "ise-2.0.0.306.SPA.x86_64.iso"
             }
         }
-
     ]
 }


### PR DESCRIPTION
* add "-smbios type=1,product=KVM" to startup arguments to pass dmidecode check in initial Cisco ISE 2.2 setup. When not given the setup process will HALT. Might work for >2.2 but not tested yet.

This global switch should not affect older images.

* fix all download links (old -> new Cisco download portal)

See https://communities.cisco.com/message/263876

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [x] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [x] GNS3 VM can run it without any tweaks.
  - [x] The device is in the right category: router, switch, guest (hosts), firewall
  - [x] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [x] When adding a container: it builds on Docker Hub and can be pulled.
- [x] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [x] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
