### PR TITLE
Update appliance hp-vsr1001

### DIFF
--- a/appliances/hp-vsr1001.gns3a
+++ b/appliances/hp-vsr1001.gns3a
@@ -4,7 +4,7 @@
     "description": "The HP VSR1000 Virtual Services Router Series is a software application, running on a server, which provides functionality similar to that of a physical router: robust routing between networked devices using a number of popular routing protocols. It also delivers the critical network services associated with today's enterprise routers such as VPN gateway, firewall and other security and traffic management functions.\n\nThe virtual services router (VSR) application runs on a hypervqcor on the server, and supports VMware vSphere and Linux KVM hypervqcors. From one to eight virtual CPUs are supported, depending on license.\n\nBecause the VSR1000 Series application runs the same HP Comware version 7 operating system as HP switches and routers, it enables significant operational savings. And being virtual, additional agility and ease of deployment is realized, as resources on the VSR can be dynamically allocated and upgraded upon demand as performance requirements grow.\n\nA variety of deployment models are supported including enterprise branch CPE routing, and cloud offload for small to medium workloads.",
     "vendor_name": "HPE",
     "vendor_url": "http://www.hpe.com",
-    "documentation_url": "http://h20195.www2.hpe.com/v2/default.aspx?cc=us&lc=en&oid=5443878",
+    "documentation_url": "https://support.hpe.com/hpesc/public/home/documentHome?document_type=135&sp4ts.oid=5195141",
     "product_name": "VSR1001",
     "product_url": "https://www.hpe.com/us/en/product-catalog/networking/networking-routers/pip.hpe-flexnetwork-vsr1000-virtual-services-router-series.5443163.html",
     "registry_version": 3,
@@ -20,7 +20,8 @@
         "arch": "x86_64",
         "console_type": "vnc",
         "boot_priority": "c",
-        "kvm": "require"
+        "kvm": "require",
+        "options": "-machine type=pc-1.0"
     },
     "images": [
         {
@@ -28,56 +29,56 @@
             "version": "7.10.R0327L01",
             "md5sum": "907de5140a4a029afe1c517cfc27ecde",
             "filesize": 138739712,
-            "download_url": "https://h10145.www1.hp.com/Downloads/DownloadSoftware.aspx?SoftwareReleaseUId=22702&ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SaidNumber="
+            "download_url": "https://h10145.www1.hpe.com/Downloads/DownloadSoftware.aspx?SoftwareReleaseUId=22702&ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SaidNumber="
         },
         {
             "filename": "VSR1000_HPE-CMW710-R0326-X64.qco",
             "version": "7.10.R0326",
             "md5sum": "4153d638bfa72ca72a957ea8682ad0e2",
             "filesize": 138412032,
-            "download_url": "https://h10145.www1.hp.com/Downloads/SoftwareReleases.aspx?ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SoftwareReleaseUId=11832&SerialNumber=&PurchaseDate="
+            "download_url": "https://h10145.www1.hpe.com/Downloads/DownloadSoftware.aspx?SoftwareReleaseUId=21985&ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SaidNumber="
         },
         {
             "filename": "VSR1000_HPE-CMW710-E0325-X64.qco",
             "version": "7.10.E0325",
             "md5sum": "a6731f3af86bee9b209a8b342be6bf75",
             "filesize": 111738880,
-            "download_url": "https://h10145.www1.hp.com/Downloads/SoftwareReleases.aspx?ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SoftwareReleaseUId=11832&SerialNumber=&PurchaseDate="
+            "download_url": "https://h10145.www1.hpe.com/Downloads/DownloadSoftware.aspx?SoftwareReleaseUId=20278&ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SaidNumber="
         },
         {
             "filename": "VSR1000_HPE-CMW710-E0518-X64.qco",
             "version": "7.10.E0518",
             "md5sum": "4991436442ae706df8041c69778a48df",
             "filesize": 201588736,
-            "download_url": "https://h10145.www1.hp.com/Downloads/SoftwareReleases.aspx?ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SoftwareReleaseUId=11832&SerialNumber=&PurchaseDate="
+            "download_url": "https://h10145.www1.hpe.com/Downloads/DownloadSoftware.aspx?SoftwareReleaseUId=21929&ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SaidNumber="
         },
         {
             "filename": "VSR1000_HPE-CMW710-E0324-X64.qco",
             "version": "7.10.E0324",
             "md5sum": "7a0ff32281284c042591c6181426effd",
             "filesize": 111411200,
-            "download_url": "https://h10145.www1.hp.com/Downloads/SoftwareReleases.aspx?ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SoftwareReleaseUId=11832&SerialNumber=&PurchaseDate="
+            "download_url": "https://h10145.www1.hpe.com/Downloads/DownloadSoftware.aspx?SoftwareReleaseUId=18977&ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SaidNumber="
         },
         {
             "filename": "VSR1000_HPE-CMW710-E0322P01-X64.qco",
             "version": "7.10.E0322P01",
             "md5sum": "0aa2dbe5910fa64eb8c623e083b21a5e",
             "filesize": 110428160,
-            "download_url": "https://h10145.www1.hp.com/Downloads/SoftwareReleases.aspx?ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SoftwareReleaseUId=11832&SerialNumber=&PurchaseDate="
+            "download_url": "https://h10145.www1.hpe.com/Downloads/DownloadSoftware.aspx?SoftwareReleaseUId=18976&ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SaidNumber="
         },
         {
             "filename": "VSR1000_HPE-CMW710-E0322-X64.qco",
             "version": "7.10.E0322",
             "md5sum": "05e0dab6b7aa489f627448b4d79b1f50",
             "filesize": 113770496,
-            "download_url": "https://h10145.www1.hp.com/Downloads/SoftwareReleases.aspx?ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SoftwareReleaseUId=11832&SerialNumber=&PurchaseDate="
+            "download_url": "https://h10145.www1.hpe.com/Downloads/DownloadSoftware.aspx?SoftwareReleaseUId=18975&ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SaidNumber="
         },
         {
             "filename": "VSR1000_HPE-CMW710-E0321P01-X64.qco",
             "version": "7.10.E0321P01",
             "md5sum": "26d4375fafeedc81f298f29f593de252",
             "filesize": 113639424,
-            "download_url": "https://h10145.www1.hp.com/Downloads/SoftwareReleases.aspx?ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SoftwareReleaseUId=11832&SerialNumber=&PurchaseDate="
+            "download_url": "https://h10145.www1.hpe.com/Downloads/DownloadSoftware.aspx?SoftwareReleaseUId=16838&ProductNumber=JG811AAE&lang=en&cc=us&prodSeriesId=5443163&SaidNumber="
         }
     ],
     "versions": [


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---

No new software version, mainly updating the URLs for the documentation and download.
I verified, that the download from the new URLs still have the same length and MD5 hash.
The product_url is invalid, but I was unable to find the current product URL for VSR on the HPE website.

I added the qemu option "-machine type=pc-1.0". Without that the linux boot loader can't load the image from the hard disk, when using QEMU v2.8.1 from Debian Stretch. It shouldn't harm with earlier QEMU versions. @adosztal , are you able to verify that?