### PR TITLE
Update Juniper vMX templates

### DIFF
--- a/appliances/juniper-vmx-vcp.gns3a
+++ b/appliances/juniper-vmx-vcp.gns3a
@@ -18,7 +18,7 @@
     "qemu": {
         "adapter_type": "e1000",
         "adapters": 2,
-        "ram": 2048,
+        "ram": 1024,
         "arch": "x86_64",
         "console_type": "telnet",
         "kvm": "require",

--- a/appliances/juniper-vmx-vcp.gns3a
+++ b/appliances/juniper-vmx-vcp.gns3a
@@ -26,6 +26,24 @@
     },
     "images": [
         {
+            "filename": "junos-vmx-x86-64-17.4R1.16.qcow2",
+            "version": "17.4R1.16-KVM",
+            "md5sum": "85239193e852d643dfd9d5c257240bdf",
+            "filesize": 1325400064
+        },
+        {
+            "filename": "vmxhdd-17.4R1.16.img",
+            "version": "17.4R1.16-KVM",
+            "md5sum": "69e9821ebc59367527336d8bcecd171c",
+            "filesize": 108986368
+        },
+        {
+            "filename": "metadata-usb-re-17.4R1.16.img",
+            "version": "17.4R1.16-KVM",
+            "md5sum": "a5b125822b798c7167c35966ea00229a",
+            "filesize": 16777216
+        },
+        {
             "filename": "vcp_17.1R1.8-disk1.vmdk",
             "version": "17.1R1.8-ESXi",
             "md5sum": "2dba6dff363c0619903f85c3dedce8d8",
@@ -261,9 +279,35 @@
             "md5sum": "af48f7e03f94ffcfeecd15a59a4f1567",
             "filesize": 16777216,
             "download_url": "http://www.juniper.net/us/en/products-services/routing/mx-series/vmx/"
+        },
+        {
+            "filename": "junos-vmx-x86-64-15.1F6.9.qcow2",
+            "version": "15.1F6.9-KVM",
+            "md5sum": "595f532b95d6d98590d0375a3d6d14b6",
+            "filesize": 994181120
+        },
+        {
+            "filename": "vmxhdd-15.1F6.9.img",
+            "version": "15.1F6.9-KVM",
+            "md5sum": "bae35d0bb72946d1e91ff9c5e7ddbf86",
+            "filesize": 108986368
+        },
+        {
+            "filename": "metadata-usb-re-15.1F6.9.img",
+            "version": "15.1F6.9-KVM",
+            "md5sum": "15238c3dbc987d1a641c919efe2731c5",
+            "filesize": 16777216
         }
     ],
     "versions": [
+        {
+            "name": "17.4R1.16-KVM",
+            "images": {
+                "hda_disk_image": "junos-vmx-x86-64-17.4R1.16.qcow2",
+                "hdb_disk_image": "vmxhdd-17.4R1.16.img",
+                "hdc_disk_image": "metadata-usb-re-17.4R1.16.img"
+            }
+        },
         {
             "name": "17.1R1.8-ESXi",
             "images": {
@@ -367,6 +411,14 @@
                 "hdb_disk_image": "vmxhdd-15.1.img",
                 "hdc_disk_image": "metadata-usb-15.1.img"
             }
-         }
+        },
+        {
+            "name": "15.1F6.9",
+            "images": {
+                "hda_disk_image": "junos-vmx-x86-64-15.1F6.9.qcow2",
+                "hdb_disk_image": "vmxhdd-15.1F6.9.img",
+                "hdc_disk_image": "metadata-usb-re-15.1F6.9.img"
+            }
+        }
     ]
 }

--- a/appliances/juniper-vmx-vfp.gns3a
+++ b/appliances/juniper-vmx-vfp.gns3a
@@ -26,12 +26,19 @@
     },
     "images": [
         {
+            "filename": "vFPC-20171213.img",
+            "version": "17.4R1.16-KVM",
+            "md5sum": "848a6256da7296e8fede368a258c68e4",
+            "filesize": 2313158656,
+            "download_url": "http://www.juniper.net/us/en/products-services/routing/mx-series/vmx/"
+        },
+        {
             "filename": "vfpc_17.1R1.8-disk1.vmdk",
             "version": "17.1R1.8-ESXi",
             "md5sum": "169dd487b8547d58b12b2918a5667360",
             "filesize": 102820352,
             "download_url": "http://www.juniper.net/us/en/products-services/routing/mx-series/vmx/"
-        }, 
+        },
         {
             "filename": "vFPC-20170216.img",
             "version": "17.1R1.8-KVM",
@@ -108,17 +115,30 @@
             "md5sum": "5ccf252002184a21413cad23fd239c3f",
             "filesize": 2313158656,
             "download_url": "http://www.juniper.net/us/en/products-services/routing/mx-series/vmx/"
-        }, 
+        },
+        {
+            "filename": "vFPC-15.1F6.9.img",
+            "version": "15.1F6.9-KVM",
+            "md5sum": "7328501fdfa9b160955bc136664f1e86",
+            "filesize": 2313158656,
+            "download_url": "http://www.juniper.net/us/en/products-services/routing/mx-series/vmx/"
+        },
         {
             "filename": "vFPC-20151203.img",
             "version": "15.1F4.15",
             "md5sum": "b3faa91b4d20836a9a6dd6bad2629dd1",
             "filesize": 2313158656,
             "download_url": "http://www.juniper.net/us/en/products-services/routing/mx-series/vmx/"
-        } 
+        }
     ],
 
     "versions": [
+        {
+            "name": "17.4R1.16-KVM",
+            "images": {
+                "hda_disk_image": "vFPC-20171213.img"
+            }
+        },
         {
             "name": "17.1R1.8-ESXi",
             "images": {
@@ -192,11 +212,17 @@
             }
         },
         {
+            "name": "15.1F6.9-KVM",
+            "images": {
+                "hda_disk_image": "vFPC-15.1F6.9.img"
+            }
+        },
+        {
             "name": "15.1F4.15",
             "images": {
                 "hda_disk_image": "vFPC-20151203.img"
             }
         }
-       
+
     ]
 }


### PR DESCRIPTION
Adds version 17.4R1.16-KVM and 15.1F6.9-KVM.

Also changes vCP ram size to 1024MB, which is enough for lite-mode as per Juniper release notes:
https://www.juniper.net/documentation/en_US/vmx18.1/information-products/topic-collections/release-notes/jd0e176.html#jd0e184

When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
