### PR TITLE
Added new definition for Aruba Virtual Mobility Controller

### DIFF
--- a/appliances/aruba-vmc.gns3a
+++ b/appliances/aruba-vmc.gns3a
@@ -52,5 +52,5 @@
     "maintainer": "Gary Ossewaarde",
     "description": "Aruba Virtual Mobility Controller",
     "first_port_name": "mgmt",
-    "registry_version": 1
+    "registry_version": 3
 }

--- a/appliances/aruba-vmc.gns3a
+++ b/appliances/aruba-vmc.gns3a
@@ -1,0 +1,56 @@
+{
+    "versions": [
+        {
+            "name": "8.2.1.1",
+            "images": {
+                "hda_disk_image": "ArubaOS_VMC_8.2.1.1_65265-disk1.qcow2",
+                "hdb_disk_image": "ArubaOS_VMC_8.2.1.1_65265-disk2.qcow2"
+            }
+        }
+    ],
+    "status": "stable",
+    "name": "Aruba VMC",
+    "product_name": "Aruba VMC",
+    "maintainer_email": "gary.ossewaarde@gmail.com",
+    "vendor_url": "arubanetworks.com",
+    "vendor_name": "HPE Aruba",
+    "images": [
+        {
+            "filename": "ArubaOS_VMC_8.2.1.1_65265-disk1.qcow2",
+            "version": "8.2.1.1",
+            "md5sum": "f3bc233f0714e4b1cc127e337d077574",
+            "filesize": 197066752,
+            "download_url": "http://support.arubanetworks.com/"
+        },
+        {
+            "filename": "ArubaOS_VMC_8.2.1.1_65265-disk2.qcow2",
+            "version": "8.2.1.1",
+            "md5sum": "18ede2afc7595fdac4508a8a3972e302",
+            "filesize": 19202048,
+            "download_url": "http://support.arubanetworks.com/"
+        }
+
+    ],
+    "port_name_format": "GE0/0/{0}",
+    "qemu": {
+        "arch": "x86_64",
+        "ram": 6144,
+        "adapters": 4,
+        "hdb_disk_interface": "ide",
+        "hdc_disk_interface": "ide",
+        "hda_disk_interface": "ide",
+        "cpus": 3,
+        "kvm": "require",
+        "kernel_command_line": "-smp cores=3,threads=1,sockets=1 -cpu host -nographic",
+        "adapter_type": "e1000",
+        "console_type": "vnc",
+        "options": "-smp cores=3,threads=1,sockets=1 -cpu host -nographic",
+        "process_priority": "normal"
+    },
+    "availability": "service-contract",
+    "category": "guest",
+    "maintainer": "Gary Ossewaarde",
+    "description": "Aruba Virtual Mobility Controller",
+    "first_port_name": "mgmt",
+    "registry_version": 1
+}

--- a/appliances/aruba-vmc.gns3a
+++ b/appliances/aruba-vmc.gns3a
@@ -52,5 +52,5 @@
     "maintainer": "Gary Ossewaarde",
     "description": "Aruba Virtual Mobility Controller",
     "first_port_name": "mgmt",
-    "registry_version": 3
+    "registry_version": 4
 }


### PR DESCRIPTION
Before submitting a pull request, please check the following.

When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ✔] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ✔ ] GNS3 VM can run it without any tweaks.
  - [ ✔ ]  The device is in the right category: router, switch, guest (hosts), firewall
  - [ ✔ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ✔ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ✔] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
--> check.py drops errors, but not for my file

- [ ] *Optional: a symbol has been created for the new appliance.*
