### PR TITLE
Add Arista cEOS

### DIFF
--- a/appliances/arista-ceos.gns3a
+++ b/appliances/arista-ceos.gns3a
@@ -1,0 +1,19 @@
+{
+    "name": "cEOS",
+    "category": "multilayer_switch",
+    "description": "Arista cEOS\u2122 introduces the containerized packaging of EOS software and its agents for deployment in cloud infrastructure with the same proven EOS software image that runs on all Arista products. These flexible deployment options empower cloud network operators that are customizing their operating environments to provide a uniform workflow for development, testing and deployment of differentiated services.",
+    "vendor_name": "Arista",
+    "vendor_url": "http://www.arista.com/",
+    "product_name": "cEOS",
+    "registry_version": 3,
+    "status": "experimental",
+    "maintainer": "GNS3 Team",
+    "maintainer_email": "developers@gns3.net",
+    "usage": "Download:\nCreate a (free) Arista account and login.\nThen navigate to Support / Software Download and download the cEOS-lab image.\n\nInstallation:\nCopy the image to your GNS3VM (or other Linux) server, then run the following commands:\n\ndocker import cEOS-lab.tar.xz ceosimage:4.20.5F\necho \"rm /etc/systemd/system/getty.target.wants/getty@tty1.service\" | \\\ndocker run --name=ceos-container -e CEOS=1 -e container=docker -e EOS_PLATFORM=ceossim -e SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 -e ETBA=1 -e INTFTYPE=eth -i ceosimage:4.20.5F sh\ndocker commit --change='CMD [\"/sbin/init\"]' --change='VOLUME /mnt/flash' ceos-container ceosimage:GNS3\ndocker rm ceos-container\n\nUsage:\nThe login is admin, with no password by default",
+    "symbol": ":/symbols/multilayer_switch.svg",
+    "docker": {
+        "adapters": 8,
+        "image": "ceosimage:GNS3",
+        "console_type": "telnet"
+    }
+}


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [x] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [x] GNS3 VM can run it without any tweaks.
  - [x] The device is in the right category: router, switch, guest (hosts), firewall
  - [x] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.  
  Image not available in Docker Hub, see below. 
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [x] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
---

Aristo doesn't publish the cEOS docker container on Docker Hub, so the installation is a bit unusual. It's based on the cEOS-lab-README.txt from Arista and documented in the usage:
```
Download:
Create a (free) Arista account and login.
Then navigate to Support / Software Download and download the cEOS-lab image.

Installation:
Copy the image to your GNS3VM (or other Linux) server, then run the following commands:
docker import cEOS-lab.tar.xz ceosimage:4.20.5F
echo "rm /etc/systemd/system/getty.target.wants/getty@tty1.service" | \
docker run --name=ceos-container -e CEOS=1 -e container=docker -e EOS_PLATFORM=ceossim -e SKIP_ZEROTOUCH_BARRIER_IN_SYSDBINIT=1 -e ETBA=1 -e INTFTYPE=eth -i ceosimage:4.20.5F sh
docker commit --change='CMD ["/sbin/init"]' --change='VOLUME /mnt/flash' ceos-container ceosimage:GNS3
docker rm ceos-container

Usage:
The login is admin, with no password by default
```

This installs the Arista docker image ceosimage:4.20.5F and then creates a derived ceosimage:GNS3, which adds the modifications to run it in GNS3. The appliance uses the ceosimage:GNS3 image.

Sporadically I noticed a runaway getty process on tty1. As this virtual terminal is not used in docker, I removed that from the systemd configuration in the docker image.