### PR TITLE
Update cisco-iosxrv9k.gns3a

### DIFF
--- a/appliances/cisco-iosxrv9k.gns3a
+++ b/appliances/cisco-iosxrv9k.gns3a
@@ -15,15 +15,21 @@
     "first_port_name": "MgmtEth0/0/CPU0/0",
     "port_name_format": "GigabitEthernet0/0/0/{0}",
     "qemu": {
-        "adapter_type": "e1000",
-        "adapters": 4,
+        "adapter_type": "virtio-net-pci",
+        "adapters": 7,
         "ram": 16384,
         "arch": "x86_64",
         "console_type": "telnet",
         "kvm": "require",
-        "options": "-smp 4"
+        "options": "-smp 4 -cpu host"
     },
     "images": [
+        {   "filename": "xrv9k-fullk9-x-6.4.1.qcow2",
+            "version": "6.4.1",
+            "md5sum": "9c56b684e307706005a503e289cb9317",
+            "filesize": 1304887296,
+            "download_url": "https://software.cisco.com/download/home/286288939/type/280805694/release/6.4.1"
+        },
         {
             "filename": "xrv9k-fullk9-x-6.2.25.qcow2",
             "version": "6.2.25",
@@ -47,6 +53,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "6.4.1",
+            "images": {
+                "hda_disk_image": "xrv9k-fullk9-x-6.4.1.qcow2"
+            }
+        },
         {
             "name": "6.2.25",
             "images": {


### PR DESCRIPTION
Added fixes from https://github.com/GNS3/gns3-gui/issues/2544 (interfaces not showing up.)
Increased interface count to 7, which allows for 1 management, 2 internal unused, and 4 usable.
Added version 6.4.1.

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
