### PR TITLE
added latest Big-iq image and version

### DIFF
--- a/appliances/f5-bigiq.gns3a
+++ b/appliances/f5-bigiq.gns3a
@@ -89,6 +89,13 @@
     ],
     "versions": [
         {
+            "name": "5.4.0.2",
+            "images": {
+                "hda_disk_image": "BIG-IQ-5.4.0.2.24.7467.qcow2",
+                "hdb_disk_image": "empty100G.qcow2"
+            }
+        },
+        {
             "name": "5.4.0",
             "images": {
                 "hda_disk_image": "BIG-IQ-5.4.0.0.0.7437.qcow2",

--- a/appliances/f5-bigiq.gns3a
+++ b/appliances/f5-bigiq.gns3a
@@ -30,10 +30,17 @@
     },
     "images": [
         {
+            "filename": "BIG-IQ-5.4.0.2.24.7467.qcow2",
+            "version": "5.4.0.2",
+            "md5sum": "e3e6389438ba1e1676f507658f767e95",
+            "filesize": 3480748032,
+            "download_url": "https://downloads.f5.com/esd/serveDownload.jsp?path=/big-iq/big-iq_cm/5.4.0/english/virtual-edition_base-plus-hf2/&sw=BIG-IQ&pro=big-iq_CM&ver=5.4.0&container=Virtual-Edition_Base-Plus-HF2&file=BIG-IQ-5.4.0.2.24.7467.qcow2.zip"
+        },
+        {
             "filename": "BIG-IQ-5.4.0.0.0.7437.qcow2",
             "version": "5.4.0",
-            "md5sum": "763b1ec32a1eb6cf1d03e6826b606443",
-            "filesize": 2181345280,
+            "md5sum": "068b1f4d21048b9b2a082c0c27ef4d53",
+            "filesize": 3300917248,
             "download_url": "https://downloads.f5.com/esd/serveDownload.jsp?path=/big-iq/big-iq_cm/5.4.0/english/v5.4.0/&sw=BIG-IQ&pro=big-iq_CM&ver=5.4.0&container=v5.4.0&file=BIG-IQ-5.4.0.0.0.7437.qcow2.zip"
         },
         {

--- a/appliances/f5-bigiq.gns3a
+++ b/appliances/f5-bigiq.gns3a
@@ -32,8 +32,8 @@
         {
             "filename": "BIG-IQ-5.4.0.0.0.7437.qcow2",
             "version": "5.4.0",
-            "md5sum": "068b1f4d21048b9b2a082c0c27ef4d53",
-            "filesize": 3300917248,
+            "md5sum": "763b1ec32a1eb6cf1d03e6826b606443",
+            "filesize": 2181345280,
             "download_url": "https://downloads.f5.com/esd/serveDownload.jsp?path=/big-iq/big-iq_cm/5.4.0/english/v5.4.0/&sw=BIG-IQ&pro=big-iq_CM&ver=5.4.0&container=v5.4.0&file=BIG-IQ-5.4.0.0.0.7437.qcow2.zip"
         },
         {


### PR DESCRIPTION
Tested OK.

---
When updating an **existing** appliance:
- [X ] The new version is on top.
- [X ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ X] If you forked the repo, running check.py doesn't drop any errors for the updated file.