### PR TITLE
turnkey docker naming convention has changed

### DIFF
--- a/appliances/turnkey-wordpress.gns3a
+++ b/appliances/turnkey-wordpress.gns3a
@@ -13,7 +13,7 @@
     "usage": "For security reasons there are no default passwords. All passwords are set at system initialization time.",
     "docker": {
         "adapters": 1,
-        "image": "turnkeylinux/wordpress-14.2:latest",
+        "image": "turnkeylinux/wordpress:latest",
         "console_type": "telnet"
     }
 }


### PR DESCRIPTION
As of the v15.0 release of TurnKey, the TurnKey Docker container naming convention has been bought into line with the Docker "norm". I.e. TurnKey is now use the naming convention: `turnkey/APP_NAME:VERSION_TAG` e.g. `turnkey/wordpress:15.2`. Previously the version was included in the name, i.e. `turnkey/APP_NAME-VERSION:latest` e.g. `turnkey/wordpress-14.2:latest`.

The `latest` tag will always pull in the latest release version (currently v15.2 in the case of WordPress) i.e. `turnkey/wordpress:latest` is _currently_ the same as `turnkey/wordpress:15.2`. Previous versions can be specified via tag, e.g. `turnkey/wordpress:15.1`.

Please note that I don't have GNS3 installed, but would assume that this should work (it works on vanilla Docker).