### PR TITLE
New releases + a workaround for #1479

### DIFF
--- a/appliances/cisco-iosxrv9k.gns3a
+++ b/appliances/cisco-iosxrv9k.gns3a
@@ -11,7 +11,7 @@
     "status": "experimental",
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
-    "usage": "Default username/password: admin/admin, cisco/cisco and lab/lab. There is no default configuration present. Interfaces may take several minutes to be usable after appliance boot.\n\nThe interfaces are mapped the following way:\n- NIC0: unused\n- NIC1: unused\n- NIC2: Gi0/0/0/0\n- NIC3:Gi0/0/0/1\n-NICn: Gi0/0/0/(n-2)",
+    "usage": "Default username/password: admin/admin, cisco/cisco and lab/lab. There is no default configuration present. Interfaces may take several minutes to be usable after appliance boot.\n\nThe interfaces are mapped the following way:\n- NIC0: unused\n- NIC1: unused\n- NIC2: Gi0/0/0/0\n- NIC3: Gi0/0/0/1\n- NICn: Gi0/0/0/(n-2)",
     "first_port_name": "MgmtEth0/0/CPU0/0",
     "port_name_format": "NIC{0}",
     "qemu": {

--- a/appliances/cisco-iosxrv9k.gns3a
+++ b/appliances/cisco-iosxrv9k.gns3a
@@ -11,9 +11,9 @@
     "status": "experimental",
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
-    "usage": "Default username/password: admin/admin, cisco/cisco and lab/lab. There is no default configuration present. Interfaces may take several minutes to be usable after appliance boot.",
+    "usage": "Default username/password: admin/admin, cisco/cisco and lab/lab. There is no default configuration present. Interfaces may take several minutes to be usable after appliance boot.\n\nThe interfaces are mapped the following way:\n- NIC0: unused\n- NIC1: unused\n- NIC2: Gi0/0/0/0\n- NIC3:Gi0/0/0/1\n-NICn: Gi0/0/0/(n-2)",
     "first_port_name": "MgmtEth0/0/CPU0/0",
-    "port_name_format": "GigabitEthernet0/0/0/{0}",
+    "port_name_format": "NIC{0}",
     "qemu": {
         "adapter_type": "virtio-net-pci",
         "adapters": 7,

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -41,6 +41,13 @@
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
+            "filename": "FGT_VM64_KVM-v5-build1653-FORTINET.out.kvm.qcow2",
+            "version": "5.6.7",
+            "md5sum": "202e1ed7582b02493be63f14cc48c2cb",
+            "filesize": 43180032,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FGT_VM64_KVM-v5-build1575-FORTINET.out.kvm.qcow2",
             "version": "5.6.4",
             "md5sum": "c312ea8ec1afffb73858fb1b15c095ef",
@@ -73,6 +80,13 @@
             "version": "5.6.0",
             "md5sum": "17ee2cc8c76c4928a68a2d016aa83ace",
             "filesize": 38760448,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FGT_VM64_KVM-v5-build1220-FORTINET.out.kvm.qcow2",
+            "version": "5.4.10",
+            "md5sum": "7444d6c85ef6b937a98163482caa5a90",
+            "filesize": 39043072,
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
@@ -219,6 +233,13 @@
             }
         },
         {
+            "name": "5.6.7",
+            "images": {
+                "hda_disk_image": "FGT_VM64_KVM-v5-build1653-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
             "name": "5.6.4",
             "images": {
                 "hda_disk_image": "FGT_VM64_KVM-v5-build1575-FORTINET.out.kvm.qcow2",
@@ -250,6 +271,13 @@
             "name": "5.6.0",
             "images": {
                 "hda_disk_image": "FGT_VM64_KVM-v5-build1449-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "5.4.10",
+            "images": {
+                "hda_disk_image": "FGT_VM64_KVM-v5-build1220-FORTINET.out.kvm.qcow2",
                 "hdb_disk_image": "empty30G.qcow2"
             }
         },

--- a/appliances/freebsd.gns3a
+++ b/appliances/freebsd.gns3a
@@ -23,6 +23,15 @@
     },
     "images": [
         {
+            "filename": "FreeBSD-12.0-RELEASE-amd64.qcow2",
+            "version": "12.0",
+            "md5sum": "4d2126ba79dad224628be6f25a908bd8",
+            "filesize": 2644836352,
+            "download_url": "https://www.freebsd.org/where.html",
+            "direct_download_url": "https://download.freebsd.org/ftp/releases/VM-IMAGES/12.0-RELEASE/amd64/Latest/FreeBSD-12.0-RELEASE-amd64.qcow2.xz",
+            "compression": "xz"
+        },
+        {
             "filename": "FreeBSD-11.2-RELEASE-amd64.qcow2",
             "version": "11.2",
             "md5sum": "44d37e65be4bb4054f067911c84d074a",
@@ -69,6 +78,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "12.0",
+            "images": {
+                "hda_disk_image": "FreeBSD-12.0-RELEASE-amd64.qcow2"
+            }
+        },
         {
             "name": "11.2",
             "images": {

--- a/appliances/freenas.gns3a
+++ b/appliances/freenas.gns3a
@@ -25,6 +25,14 @@
     },
     "images": [
         {
+            "filename": "FreeNAS-11.2-RELEASE.iso",
+            "version": "11.2",
+            "md5sum": "bf4a9ebb19313c3d45f84c1550477727",
+            "filesize": 603410432,
+            "download_url": "http://www.freenas.org/download/",
+            "direct_download_url": "https://download.freenas.org/11.2/STABLE/RELEASE/x64/FreeNAS-11.2-RELEASE.iso"
+        },
+        {
             "filename": "FreeNAS-11.1-U6.iso",
             "version": "11.1 U6",
             "md5sum": "633d6444cad903c707983b54e04fc053",
@@ -82,6 +90,14 @@
         }
     ],
     "versions": [
+        {
+            "name": "11.2",
+            "images": {
+                "hda_disk_image": "empty30G.qcow2",
+                "hdb_disk_image": "empty30G.qcow2",
+                "cdrom_image": "FreeNAS-11.2-RELEASE.iso"
+            }
+        },
         {
             "name": "11.1 U6",
             "images": {


### PR DESCRIPTION
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
