### PR TITLE
Adjust arista-veos image mounts to boot from CDROM

### DIFF
--- a/appliances/arista-veos.gns3a
+++ b/appliances/arista-veos.gns3a
@@ -21,6 +21,7 @@
         "ram": 2048,
         "arch": "x86_64",
         "console_type": "telnet",
+	"boot_priority": "d",
         "kvm": "require"
     },
     "images": [
@@ -29,6 +30,13 @@
             "version": "4.21.1.1F",
             "md5sum": "02bfb7e53781fd44ff02357f201586d9",
             "filesize": 358809600,
+            "download_url": "https://www.arista.com/en/support/software-download"
+        },
+        {
+            "filename": "vEOS-lab-4.20.11M.vmdk",
+            "version": "4.20.11M",
+            "md5sum": "19e482a193f237c157ce35c389ca9417",
+            "filesize": 658178048,
             "download_url": "https://www.arista.com/en/support/software-download"
         },
         {
@@ -125,94 +133,101 @@
     ],
     "versions": [
         {
-            "name": "4.21.1F",
+            "name": "4.21.1.1F",
             "images": {
-                "hda_disk_image": "Aboot-veos-serial-8.0.0.iso",
-                "hdb_disk_image": "vEOS-lab-4.21.1.1F.vmdk"
+                "cdrom_image": "Aboot-veos-serial-8.0.0.iso",
+                "hda_disk_image": "vEOS-lab-4.21.1.1F.vmdk"
+            }
+        },
+        {
+            "name": "4.20.11M",
+            "images": {
+                "cdrom_image": "Aboot-veos-serial-8.0.0.iso",
+                "hda_disk_image": "vEOS-lab-4.20.11M.vmdk"
             }
         },
         {
             "name": "4.20.1F",
             "images": {
-                "hda_disk_image": "Aboot-veos-serial-8.0.0.iso",
-                "hdb_disk_image": "vEOS-lab-4.20.1F.vmdk"
+                "cdrom_image": "Aboot-veos-serial-8.0.0.iso",
+                "hda_disk_image": "vEOS-lab-4.20.1F.vmdk"
             }
         },
         {
             "name": "4.18.5M",
             "images": {
-                "hda_disk_image": "Aboot-veos-serial-8.0.0.iso",
-                "hdb_disk_image": "vEOS-lab-4.18.5M.vmdk"
+                "cdrom_image": "Aboot-veos-serial-8.0.0.iso",
+                "hda_disk_image": "vEOS-lab-4.18.5M.vmdk"
             }
         },
         {
             "name": "4.18.1F",
             "images": {
-                "hda_disk_image": "Aboot-veos-serial-8.0.0.iso",
-                "hdb_disk_image": "vEOS-lab-4.18.1F.vmdk"
+                "cdrom_image": "Aboot-veos-serial-8.0.0.iso",
+                "hda_disk_image": "vEOS-lab-4.18.1F.vmdk"
             }
         },
         {
             "name": "4.17.8M",
             "images": {
-                "hda_disk_image": "Aboot-veos-serial-8.0.0.iso",
-                "hdb_disk_image": "vEOS-lab-4.17.8M.vmdk"
+                "cdrom_image": "Aboot-veos-serial-8.0.0.iso",
+                "hda_disk_image": "vEOS-lab-4.17.8M.vmdk"
             }
         },
         {
             "name": "4.17.2F",
             "images": {
-                "hda_disk_image": "Aboot-veos-serial-8.0.0.iso",
-                "hdb_disk_image": "vEOS-lab-4.17.2F.vmdk"
+                "cdrom_image": "Aboot-veos-serial-8.0.0.iso",
+                "hda_disk_image": "vEOS-lab-4.17.2F.vmdk"
             }
         },
         {
             "name": "4.16.13M",
             "images": {
-                "hda_disk_image": "Aboot-veos-serial-8.0.0.iso",
-                "hdb_disk_image": "vEOS-lab-4.16.13M.vmdk"
+                "cdrom_image": "Aboot-veos-serial-8.0.0.iso",
+                "hda_disk_image": "vEOS-lab-4.16.13M.vmdk"
             }
         },
         {
             "name": "4.16.6M",
             "images": {
-                "hda_disk_image": "Aboot-veos-serial-8.0.0.iso",
-                "hdb_disk_image": "vEOS-lab-4.16.6M.vmdk"
+                "cdrom_image": "Aboot-veos-serial-8.0.0.iso",
+                "hda_disk_image": "vEOS-lab-4.16.6M.vmdk"
             }
         },
         {
             "name": "4.15.10M",
             "images": {
-                "hda_disk_image": "Aboot-veos-serial-8.0.0.iso",
-                "hdb_disk_image": "vEOS-lab-4.15.10M.vmdk"
+                "cdrom_image": "Aboot-veos-serial-8.0.0.iso",
+                "hda_disk_image": "vEOS-lab-4.15.10M.vmdk"
             }
         },
         {
             "name": "4.15.5M",
             "images": {
-                "hda_disk_image": "Aboot-veos-serial-8.0.0.iso",
-                "hdb_disk_image": "vEOS-lab-4.15.5M.vmdk"
+                "cdrom_image": "Aboot-veos-serial-8.0.0.iso",
+                "hda_disk_image": "vEOS-lab-4.15.5M.vmdk"
             }
         },
         {
             "name": "4.14.14M",
             "images": {
-                "hda_disk_image": "Aboot-veos-serial-8.0.0.iso",
-                "hdb_disk_image": "vEOS-lab-4.14.14M.vmdk"
+                "cdrom_image": "Aboot-veos-serial-8.0.0.iso",
+                "hda_disk_image": "vEOS-lab-4.14.14M.vmdk"
             }
         },
         {
             "name": "4.13.16M",
             "images": {
-                "hda_disk_image": "Aboot-veos-serial-8.0.0.iso",
-                "hdb_disk_image": "vEOS-lab-4.13.16M.vmdk"
+                "cdrom_image": "Aboot-veos-serial-8.0.0.iso",
+                "hda_disk_image": "vEOS-lab-4.13.16M.vmdk"
             }
         },
         {
             "name": "4.13.8M",
             "images": {
-                "hda_disk_image": "Aboot-veos-serial-8.0.0.iso",
-                "hdb_disk_image": "vEOS-lab-4.13.8M.vmdk"
+                "cdrom_image": "Aboot-veos-serial-8.0.0.iso",
+                "hda_disk_image": "vEOS-lab-4.13.8M.vmdk"
             }
         }
     ]


### PR DESCRIPTION
Move Aboot ISO from hda_disk_image to cdrom_image
Move VMDK from hdb_disk_image to hda_disk_image
Set boot_priority to "d" to boot from CD/DVD
Add Arista vEOS version 4.20.11M

Verified that v4.18.5M, v4.20.1F, v4.20.11M, v4.21.1.1F all work without tweaks when using this adjusted appliance file and GNS3 2.1.11. Earlier versions of GNS3 that contain the boot_priority bug for QEMU based appliances do have a problem with it if that is a concern.

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ X] The new version is on top.
- [ X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
