### PR TITLE
New release

### DIFF
--- a/appliances/coreos.gns3a
+++ b/appliances/coreos.gns3a
@@ -22,6 +22,15 @@
     },
     "images": [
         {
+            "filename": "coreos_production_qemu_image.1911.5.0.img",
+            "version": "1911.5.0",
+            "md5sum": "3b5b33697cfc545d8eb9fb461c612e76",
+            "filesize": 940507136,
+            "download_url": "http://stable.release.core-os.net/amd64-usr/1911.5.0/",
+            "direct_download_url": "http://stable.release.core-os.net/amd64-usr/1911.5.0/coreos_production_qemu_image.img.bz2",
+            "compression": "bzip2"
+        },
+        {
             "filename": "coreos_production_qemu_image.1855.5.0.img",
             "version": "1855.5.0",
             "md5sum": "6b5b06bc47446277c5c536c09b5a7988",
@@ -176,6 +185,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "1911.5.0",
+            "images": {
+                "hda_disk_image": "coreos_production_qemu_image.1911.5.0.img"
+            }
+        },
         {
             "name": "1855.5.0",
             "images": {

--- a/appliances/cumulus-vx.gns3a
+++ b/appliances/cumulus-vx.gns3a
@@ -24,6 +24,14 @@
     },
     "images": [
         {
+            "filename": "cumulus-linux-3.7.2-vx-amd64-qemu.qcow2",
+            "version": "3.7.2",
+            "md5sum": "2fcd785da0452e403c44ba5f3ac4e870",
+            "filesize": 1574502400,
+            "download_url": "https://cumulusnetworks.com/cumulus-vx/download/",
+            "direct_download_url": "http://cumulusfiles.s3.amazonaws.com/CumulusLinux-3.7.2/cumulus-linux-3.7.2-vx-amd64-qemu.qcow2"
+        },
+        {
             "filename": "cumulus-linux-3.7.1-vx-amd64-qemu.qcow2",
             "version": "3.7.1",
             "md5sum": "201055c57e4a20bb5772289ea6216631",
@@ -181,6 +189,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "3.7.2",
+            "images": {
+                "hda_disk_image": "cumulus-linux-3.7.2-vx-amd64-qemu.qcow2"
+            }
+        },    
         {
             "name": "3.7.1",
             "images": {

--- a/appliances/fortianalyzer.gns3a
+++ b/appliances/fortianalyzer.gns3a
@@ -28,7 +28,7 @@
     "images": [
         {
             "filename": "FAZ_VM64_KVM-v6-build0255-FORTINET.out.kvm.qcow2",
-            "version": "6.0.4",
+            "version": "6.0.3",
             "md5sum": "14c98b20ed1d0729e2d04aad49ff1be5",
             "filesize": 114589696,
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"

--- a/appliances/kali-linux.gns3a
+++ b/appliances/kali-linux.gns3a
@@ -21,12 +21,20 @@
     },
     "images": [
         {
-            "filename": "kali-linux-2018.3-amd64.iso",
-            "version": "2018.3",
-            "md5sum": "6dc3e57177249f73492b9edb95d082d1",
-            "filesize": 3188391936,
+            "filename": "kali-linux-2018.4-amd64.iso",
+            "version": "2018.4",
+            "md5sum": "1b2d598bb8d2003e6207c119c0ba42fe",
+            "filesize": 3139436544,
             "download_url": "https://www.kali.org/downloads/",
-            "direct_download_url": "http://cdimage.kali.org/kali-2018.3/kali-linux-2018.3-amd64.iso"
+            "direct_download_url": "http://cdimage.kali.org/kali-2018.4/kali-linux-2018.4-amd64.iso"
+        },
+        {
+            "filename": "kali-linux-2018.3a-amd64.iso",
+            "version": "2018.3a",
+            "md5sum": "2da675d016bd690c05e180e33aa98b94",
+            "filesize": 3192651776,
+            "download_url": "https://www.kali.org/downloads/",
+            "direct_download_url": "http://cdimage.kali.org/kali-2018.3a/kali-linux-2018.3a-amd64.iso"
         },
         {
             "filename": "kali-linux-2018.1-amd64.iso",
@@ -87,11 +95,18 @@
     ],
     "versions": [
         {
-            "name": "2018.3",
+            "name": "2018.4",
             "images": {
-                "cdrom_image": "kali-linux-2018.3-amd64.iso"
+                "cdrom_image": "kali-linux-2018.4-amd64.iso"
             }
-        },        {
+        },
+        {
+            "name": "2018.3a",
+            "images": {
+                "cdrom_image": "kali-linux-2018.3a-amd64.iso"
+            }
+        },
+        {
             "name": "2018.1",
             "images": {
                 "cdrom_image": "kali-linux-2018.1-amd64.iso"

--- a/appliances/untangle.gns3a
+++ b/appliances/untangle.gns3a
@@ -25,6 +25,13 @@
     },
     "images": [
         {
+            "filename": "untangle_1410_x64.iso",
+            "version": "14.1.0",
+            "md5sum": "49bb09e4796f225f482ca1d9c93de66b",
+            "filesize": 682622976,
+            "download_url": "https://www.untangle.com/get-untangle/"
+        },
+        {
             "filename": "untangle_1401_x64.iso",
             "version": "14.0.1",
             "md5sum": "d9c01afd8bf4b5dfdc40c22aa3b2fd98",
@@ -111,6 +118,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "14.1.0",
+            "images": {
+                "hda_disk_image": "empty30G.qcow2",
+                "cdrom_image": "untangle_1410_x64.iso"
+            }
+        },
         {
             "name": "14.0.1",
             "images": {


### PR DESCRIPTION
+ a typo fix for FortiAnalyzer
---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
