### PR TITLE
New Release - ArubaOS-CX Simulation v10.01.0001

### DIFF
--- a/appliances/aruba-arubaoscx.gns3a
+++ b/appliances/aruba-arubaoscx.gns3a
@@ -1,0 +1,53 @@
+{
+    "name": "ArubaOS-CX Simulation Software",
+    "category": "multilayer_switch",
+    "status": "stable",
+    "product_name": "ArubaOS-CX Simulation Software",
+    "description": "The ArubaOS-CX Simulation Software OVA is a virtual platform to enable simulation of the ArubaOS-CX Network Operating System. Simulated networks can be created using many of the protocols in the ArubaOS-CX Operating system like OSPF and BGP. Key features like the Aruba Network Analytics Engine and the REST API can be simulated, providing a lightweight development platform to building the modern network. This software can be easily implemented in the GNS3 simulation software to enable drag and drop network design for building complex simulated topologies.",
+    "maintainer_email": "alloytm@gmail.com",
+    "vendor_url": "arubanetworks.com",
+    "vendor_name": "HPE Aruba",
+    "availability": "service-contract",
+    "maintainer": "Tak Mem Loy",
+    "registry_version": 4,
+    "usage": "Default username admin with blank password.",
+    "symbol": ":/symbols/route_switch_processor.svg",
+    "first_port_name": "mgmt",
+    "port_name_format": "1/1/{0}",
+
+    "qemu": {
+        "arch": "x86_64",
+        "ram": 4096,
+        "adapters": 8,
+        "hdb_disk_interface": "ide",
+        "hdc_disk_interface": "ide",
+        "hda_disk_interface": "ide",
+        "cpus": 2,
+        "kvm": "require",
+        "adapter_type": "virtio-net-pci",
+        "console_type": "vnc",
+        "options": "-nographic",
+        "process_priority": "normal"
+    },   
+
+    "images": [
+        {
+            "filename": "arubaoscx-disk-image-genericx86-p4-20180712161119.vmdk",
+            "version": "10.01.0001",
+            "md5sum": "9146ae0ac650d8206c9600e03753f022",
+            "filesize": 287734784,
+            "download_url": "http://support.arubanetworks.com/"
+        }
+
+    ],
+
+    "versions": [
+        {
+            "name": "10.01.0001",
+            "images": {
+                "hda_disk_image": "arubaoscx-disk-image-genericx86-p4-20180712161119.vmdk"
+            }
+        }
+    ]    
+    
+}


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ ] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [x] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [x] GNS3 VM can run it without any tweaks.
  - [x] The device is in the right category: router, switch, guest (hosts), firewall
  - [x] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [x] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
The errors dont look like from the appliance file:
=> Check symbols
Check router_green.svg
Traceback (most recent call last):
  File "check.py", line 127, in <module>
    main()
  File "check.py", line 120, in main
    check_symbol(symbol)
  File "check.py", line 105, in check_symbol
    height = int(subprocess.check_output(['identify', '-format', '%h', os.path.join('symbols', symbol)], shell=False))
  File "/usr/lib/python3.6/subprocess.py", line 336, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.6/subprocess.py", line 403, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.6/subprocess.py", line 709, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1344, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'identify': 'identify'

- [ ] *Optional: a symbol has been created for the new appliance.*
