### PR TITLE
Make installation of imagemagick optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Check appliance files
     python check.py
     python3 check_urls.py
 
-if `imagemagick` is installed, it will be used to check the symbol properties.
+If `imagemagick` is installed, it will be used to check the symbol properties.
 Otherwise an (experimental) internal function will do that.
 
 Create a new appliance

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,8 @@ Check appliance files
     python check.py
     python3 check_urls.py
 
-You need to install `imagemagick` before running check.py.
+if `imagemagick` is installed, it will be used to check the symbol properties.
+Otherwise an (experimental) internal function will do that.
 
 Create a new appliance
 -----------------------

--- a/check.py
+++ b/check.py
@@ -105,7 +105,7 @@ unit2px = {'cm': 35.43307, 'mm': 3.543307, 'in': 90.0,
 def svg_get_height(filename):
     with open(filename, 'r') as image_file:
         image_data = image_file.read()
-    match = re.search('<svg[^>]* height="([^"]+)"', image_data)
+    match = re.search('<svg[^>]*\sheight="([^"]+)"', image_data)
     if not match:
         print("{}: can't determine the image height".format(filename))
         sys.exit(1)

--- a/check.py
+++ b/check.py
@@ -19,6 +19,8 @@ import os
 import jsonschema
 import json
 import sys
+import re
+import shutil
 import subprocess
 
 
@@ -97,12 +99,45 @@ def check_packer(packer):
                 json.load(f)
 
 
+unit2px = {'cm': 35.43307, 'mm': 3.543307, 'in': 90.0,
+           'pc': 15.0, 'pt': 1.25, 'px': 1.0}
+
+def svg_get_height(filename):
+    with open(filename, 'r') as image_file:
+        image_data = image_file.read()
+    match = re.search('<svg[^>]* height="([^"]+)"', image_data)
+    if not match:
+        print("{}: can't determine the image height".format(filename))
+        sys.exit(1)
+    height = match.group(1)
+
+    unit = height[-2:]
+    if unit in unit2px:
+        factor = unit2px[unit]
+        height = height[:-2]
+    else:
+        factor = 1.0
+
+    try:
+        height = round(float(height) * factor)
+    except ValueError:
+        print("{}: can't determine the image height".format(filename))
+        sys.exit(1)
+
+    return height
+
+
+use_imagemagick = shutil.which("identify")
+
 def check_symbol(symbol):
     licence_file = os.path.join('symbols', symbol.replace('.svg', '.txt'))
     if not os.path.exists(licence_file):
         print("Missing licence {} for {}".format(licence_file, symbol))
         sys.exit(1)
-    height = int(subprocess.check_output(['identify', '-format', '%h', os.path.join('symbols', symbol)], shell=False))
+    if use_imagemagick:
+        height = int(subprocess.check_output(['identify', '-format', '%h', os.path.join('symbols', symbol)], shell=False))
+    else:
+        height = svg_get_height(os.path.join('symbols', symbol))
     if height > 70:
         print("Symbol height of {} is too big {} > 70".format(symbol, height))
         sys.exit(1)


### PR DESCRIPTION
Previously `check.py` requires the installation of imagemagick. As imagemagick is a quite big package with a lot of dependencies, I'm not too enthusiastic to install it just for `check.py`.

This PR adds an internal routine to parse a SVG and calculate the image height. So imagemagick is not needed, but if it's installed, it will still be used instead of the new internal function.

So this won't break working installation, but new installations can try without imagemagick.