### PR TITLE
FD.IO VPP router/switch appliance

### DIFF
--- a/appliances/vpp.gns3a
+++ b/appliances/vpp.gns3a
@@ -25,8 +25,6 @@
         "options": "-nographic -cpu host -smp 2"
     },
     "images": [
-
-
         {
             "filename": "vpp_public-18.10-07.qcow2",
             "version": "0.7",

--- a/appliances/vpp.gns3a
+++ b/appliances/vpp.gns3a
@@ -1,0 +1,48 @@
+{
+    "name": "VPP",
+    "category": "router",
+    "description": "Vector Packet Processing (VPP) platform",
+    "vendor_name": "FD.IO VPP router",
+    "vendor_url": "https://fd.io/",
+    "documentation_url": "https://fd.io/resources/",
+    "product_name": "VPP",
+    "registry_version": 4,
+    "status": "experimental",
+    "availability": "free",
+    "maintainer": "Virginijus Magelinskas",
+    "maintainer_email": "virginijus.m@gmail.com",
+    "usage": "Login: root , pass: vpp. This appliance requires >2 vCPUs and 4GB of RAM to run",
+    "port_name_format": "eth{0}",
+    "qemu": {
+        "adapter_type": "virtio-net-pci",
+        "adapters": 5,
+        "ram": 4096,
+        "hda_disk_interface": "ide",
+        "arch": "x86_64",
+        "console_type": "telnet",
+        "boot_priority": "c",
+        "kvm": "require",
+        "options": "-nographic -cpu host -smp 2"
+    },
+    "images": [
+
+
+        {
+            "filename": "vpp_public-18.10-07.qcow2",
+            "version": "0.7",
+            "md5sum": "3e962985e5bbda0de4dc7893e60f6366",
+            "filesize": 2065825792,
+            "direct_download_url": "https://sigaba.net/vpp/vpp_public-18.10-07.qcow2"
+        }
+    ],
+    "versions": [
+
+        {
+            "name": "18.10-07",
+            "images": {
+                "hda_disk_image": "vpp_public-18.10-07.qcow2"
+            }
+        }
+    ]
+}
+


### PR DESCRIPTION
- It's tested locally:
  - [ X] I dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
```
[root@localhost ~]# vppctl show version
vpp v18.10-19~ga8e3001~b67 built by root on 94a8153df066 at Mon Dec 17 12:23:05 UTC 2018
```
```
--- 8.8.8.8 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 1.251/1.251/1.251/0.000 ms
```


  - [X ] GNS3 VM can run it without any tweaks.
  - [ X] The device is in the right category: router, switch, guest (hosts), firewall
  - [ X] I filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [X ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [X ]  running check.py doesn't drop any errors for the new file.

