### PR TITLE
Add mininet appliance

### DIFF
--- a/appliances/mininet.gns3a
+++ b/appliances/mininet.gns3a
@@ -5,7 +5,7 @@
     "maintainer_email": "developers@gns3.net",
     "description": "Mininet creates a realistic virtual network, running real kernel, switch and application code, on a single machine (VM, cloud or native), in seconds, with a single command.",
     "product_name": "Mininet",
-    "registry_version": 5,
+    "registry_version": 4,
     "product_url": "http://mininet.org/",
     "documentation_url": "http://mininet.org/walkthrough/",
     "first_port_name": "eth0",

--- a/appliances/mininet.gns3a
+++ b/appliances/mininet.gns3a
@@ -1,0 +1,46 @@
+{
+    "category": "guest",
+    "status": "stable",
+    "maintainer": "GNS3 Team",
+    "maintainer_email": "developers@gns3.net",
+    "description": "Mininet creates a realistic virtual network, running real kernel, switch and application code, on a single machine (VM, cloud or native), in seconds, with a single command.",
+    "product_name": "Mininet",
+    "registry_version": 5,
+    "product_url": "http://mininet.org/",
+    "documentation_url": "http://mininet.org/walkthrough/",
+    "first_port_name": "eth0",
+    "usage": "Username: mininet\nPassword: mininet",
+    "port_name_format": "eth{0}",
+    "vendor_name": "Mininet Team",
+    "qemu": {
+        "adapters": 1,
+        "adapter_type": "virtio-net-pci",
+        "arch": "x86_64",
+        "ram": 2048,
+        "console_type": "vnc",
+        "hda_disk_interface": "virtio",
+        "kvm": "allow"
+    },
+    "availability": "free",
+    "vendor_url": "http://mininet.org/",
+    "name": "Mininet",
+    "images": [
+        {
+            "filename": "mininet-vm-x86_64.vmdk",
+            "version": "2.2.2",
+            "md5sum": "a683441642300bdaf37b8e614de85342",
+            "filesize": 2047868928,
+            "download_url": "https://github.com/mininet/mininet/releases/",
+            "direct_download_url": "https://github.com/mininet/mininet/releases/download/2.2.2/mininet-2.2.2-170321-ubuntu-14.04.4-server-amd64.zip",
+            "compression": "zip"
+        }
+    ],
+    "versions": [
+        {
+            "images": {
+                "hda_disk_image": "mininet-vm-x86_64.vmdk"
+            },
+            "name": "2.2.2"
+        }
+    ]
+}


### PR DESCRIPTION
Mininet creates a realistic virtual network, running real kernel, switch and application code, on a single machine (VM, cloud or native), in seconds, with a single command.

Mininet is also a great way to develop, share, and experiment with OpenFlow and Software-Defined Networking systems.

---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [X] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [X] GNS3 VM can run it without any tweaks.
  - [X] The device is in the right category: router, switch, guest (hosts), firewall
  - [X] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [X] When adding a container: it builds on Docker Hub and can be pulled.
- [X] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [X] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
