### PR TITLE
Add CSR1000v 16.10.1b

### DIFF
--- a/appliances/cisco-csr1000v.gns3a
+++ b/appliances/cisco-csr1000v.gns3a
@@ -23,6 +23,13 @@
     },
     "images": [
         {
+            "filename": "csr1000v-universalk9.16.10.01b-serial.qcow2",
+            "version": "16.10.1b",
+            "md5sum": "0d3d647f83631c7955ad7899e6cce293",
+            "filesize": 950468608,
+            "download_url": "https://software.cisco.com/download/home/284364978/type/282046477/release/Gibraltar-16.10.1b"
+        },
+        {
             "filename": "csr1000v-universalk9.16.09.01-serial.qcow2",
             "version": "16.9.1",
             "md5sum": "d7e1c83b6f513beb4200c7691d119086",
@@ -108,6 +115,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "16.10.1b",
+            "images": {
+                "hda_disk_image": "csr1000v-universalk9.16.10.01b-serial.qcow2"
+            }
+        },
         {
             "name": "16.9.1",
             "images": {


### PR DESCRIPTION
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.

