### PR TITLE
New nsoxv versions

### DIFF
--- a/appliances/cisco-nxosv9k.gns3a
+++ b/appliances/cisco-nxosv9k.gns3a
@@ -26,11 +26,32 @@
     },
     "images": [
         {
+            "filename": "nxosv-final.9.2.3.qcow2",
+            "version": "9.2.3",
+            "md5sum": "74bd9a5b4970e868685f753e48979194",
+            "filesize": 1357643776,
+            "download_url": "https://software.cisco.com/download/home/286312239/type/282088129/release/9.2%25283%2529"
+        },
+        {
+            "filename": "nxosv-final.9.2.2.qcow2",
+            "version": "9.2.2",
+            "md5sum": "2119702c488552fc4d1b4210a04d4f64",
+            "filesize": 1344077824,
+            "download_url": "https://software.cisco.com/download/home/286312239/type/282088129/release/9.2%25281%2529"
+        },
+        {
             "filename": "nxosv-final.9.2.1.qcow2",
             "version": "9.2.1",
             "md5sum": "1d7fa4654602d7ffbf62544edfe71986",
             "filesize": 1330315264,
             "download_url": "https://software.cisco.com/download/home/286312239/type/282088129/release/9.2%25281%2529"
+        },
+        {
+            "filename": "nxosv-final.7.0.3.I7.6.qcow2",
+            "version": "7.0.3.I7.6",
+            "md5sum": "a122ee954b4c11761abd99291b70544e",
+            "filesize": 1031995392,
+            "download_url": "https://software.cisco.com/download/home/286312239/type/282088129/release/7.0%25283%2529I7%25286%2529"
         },
         {
             "filename": "nxosv-final.7.0.3.I7.5.qcow2",
@@ -100,10 +121,31 @@
     ],
     "versions": [
         {
+            "name": "9.2.3",
+            "images": {
+                "bios_image": "OVMF-20160813.fd",
+                "hda_disk_image": "nxosv-final.9.2.3.qcow2"
+            }
+        },
+        {
+            "name": "9.2.2",
+            "images": {
+                "bios_image": "OVMF-20160813.fd",
+                "hda_disk_image": "nxosv-final.9.2.2.qcow2"
+            }
+        },
+        {
             "name": "9.2.1",
             "images": {
                 "bios_image": "OVMF-20160813.fd",
                 "hda_disk_image": "nxosv-final.9.2.1.qcow2"
+            }
+        },
+        {
+            "name": "7.0.3.I7.6",
+            "images": {
+                "bios_image": "OVMF-20160813.fd",
+                "hda_disk_image": "nxosv-final.7.0.3.I7.6.qcow2"
             }
         },
         {


### PR DESCRIPTION
Added 9.2.3, 9.2.2, 7.0.3.I7.6

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x ] The new version is on top.
- [ x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ ] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
