### PR TITLE
New FRR release - for #420

### DIFF
--- a/appliances/frr.gns3a
+++ b/appliances/frr.gns3a
@@ -14,12 +14,22 @@
     "qemu": {
         "adapter_type": "virtio-net-pci",
         "adapters": 8,
-        "ram": 256,
+        "ram": 512,
+        "hda_disk_interface": "virtio",
         "arch": "x86_64",
         "console_type": "telnet",
         "kvm": "require"
     },
     "images": [
+        {
+            "filename": "frr7.0-vm0.3.qcow2",
+            "version": "FRR7.0 - VM0.3",
+            "md5sum": "5fa8ce0ee74215f4c4a8c61778ee0b10",
+            "filesize": 2044657664,
+            "download_url": "https://sourceforge.net/projects/frr/files/",
+            "direct_download_url": "https://sourceforge.net/projects/frr/files/FRR7.0-VM0.3.qcow2.bz2/download",
+            "compression": "bzip2"
+        },
         {
             "filename": "frr6.0-vm0.2.qcow2",
             "version": "FRR6.0 - VM0.2",
@@ -40,6 +50,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "FRR7.0 - VM0.3",
+            "images": {
+                "hda_disk_image": "frr7.0-vm0.3.qcow2"
+            }
+        },
         {
             "name": "FRR6.0 - VM0.2",
             "images": {


### PR DESCRIPTION
The base image has been updated to Ubuntu Server 18.04, FRR to
version 7.0. Memory size was adjusted as well because the base image
does not boot with 256 MB RAM.

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
