### PR TITLE
Added 30.2 EXOS image

### DIFF
--- a/appliances/exos.gns3a
+++ b/appliances/exos.gns3a
@@ -29,6 +29,13 @@
     "images": [
 
 		{
+            "filename": "EXOS-VM_v30.2.1.8.qcow2",
+            "version": "30.2.1.8",
+            "md5sum": "4bdbf3ddff7a030e19c6bb71270b56d2",
+            "filesize": 355205120,
+            "direct_download_url": "https://akamai-ep.extremenetworks.com/Extreme_P/github-en/Virtual_EXOS/EXOS-VM_v30.2.1.8.qcow2"
+        },
+		{
             "filename": "EXOS-VM_v30.1.1.4.qcow2",
             "version": "30.1.1.4",
             "md5sum": "92d3f9b13d750f7bfa804823fa545772",
@@ -88,6 +95,13 @@
     ],
     
     "versions": [
+
+        {
+            "name": "30.2.1.8",
+            "images": {
+                "hda_disk_image": "EXOS-VM_v30.2.1.8.qcow2"
+            }
+        },
         {
             "name": "30.1.1.4",
             "images": {


### PR DESCRIPTION
Updated to add the 30.2 Image.

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ x] The new version is on top.
- [ x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x ] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [x ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [x ] GNS3 VM can run it without any tweaks.
  - [x ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ x] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ x] When adding a container: it builds on Docker Hub and can be pulled.
- [x ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ x] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*

Everything is ok!