### PR TITLE
Kali Linux - add persistence

### DIFF
--- a/appliances/kali-linux.gns3a
+++ b/appliances/kali-linux.gns3a
@@ -10,31 +10,33 @@
     "status": "stable",
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
-    "usage": "Default password is toor",
+    "usage": "Default password is toor\nEnable persistence by selecting boot option 'Live USB Persistence'",
+    "port_name_format": "eth{0}",
     "qemu": {
         "adapter_type": "e1000",
         "adapters": 8,
         "ram": 1024,
         "arch": "x86_64",
         "console_type": "vnc",
+        "boot_priority": "d",
         "kvm": "require"
     },
     "images": [
-        {
-            "filename": "kali-linux-mate-2019.2-amd64.iso",
-            "version": "2019.2 (MATE)",
-            "md5sum": "fec8dd7009f932c51a74323df965a709",
-            "filesize": 3313217536,
-            "download_url": "https://www.kali.org/downloads/",
-            "direct_download_url": "http://cdimage.kali.org/kali-2019.1a/kali-linux-mate-2019.2-amd64.iso"
-        },
         {
             "filename": "kali-linux-2019.2-amd64.iso",
             "version": "2019.2",
             "md5sum": "0f89b6225d7ea9c18682f7cc541c1179",
             "filesize": 3353227264,
             "download_url": "https://www.kali.org/downloads/",
-            "direct_download_url": "http://cdimage.kali.org/kali-2019.1a/kali-linux-2019.2-amd64.iso"
+            "direct_download_url": "http://cdimage.kali.org/kali-2019.2/kali-linux-2019.2-amd64.iso"
+        },
+        {
+            "filename": "kali-linux-mate-2019.2-amd64.iso",
+            "version": "2019.2 (MATE)",
+            "md5sum": "fec8dd7009f932c51a74323df965a709",
+            "filesize": 3313217536,
+            "download_url": "https://www.kali.org/downloads/",
+            "direct_download_url": "http://cdimage.kali.org/kali-2019.2/kali-linux-mate-2019.2-amd64.iso"
         },
         {
             "filename": "kali-linux-2019.1a-amd64.iso",
@@ -115,78 +117,98 @@
             "filesize": 3320512512,
             "download_url": "https://www.offensive-security.com/kali-linux-vmware-arm-image-download/",
             "direct_download_url": "http://images.kali.org/Kali-Linux-2.0.0-vm-amd64.7z"
+        },
+        {
+            "filename": "kali-linux-persistence-1gb.qcow2",
+            "version": "1.0",
+            "md5sum": "3c67948673377740c0b4bbdc2920da52",
+            "filesize": 34734080,
+            "download_url": "https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/",
+            "direct_download_url": "https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/kali-linux-persistence-1gb.qcow2/download"
         }
     ],
     "versions": [
         {
-            "name": "2019.2 (MATE)",
+            "name": "2019.2",
             "images": {
-                "cdrom_image": "kali-linux-mate-2019.2-amd64.iso"
+                "hda_disk_image": "kali-linux-persistence-1gb.qcow2",
+                "cdrom_image": "kali-linux-2019.2-amd64.iso"
             }
         },
         {
-            "name": "2019.2",
+            "name": "2019.2 (MATE)",
             "images": {
-                "cdrom_image": "kali-linux-2019.2-amd64.iso"
+                "hda_disk_image": "kali-linux-persistence-1gb.qcow2",
+                "cdrom_image": "kali-linux-mate-2019.2-amd64.iso"
             }
         },
         {
             "name": "2019.1a",
             "images": {
+                "hda_disk_image": "kali-linux-persistence-1gb.qcow2",
                 "cdrom_image": "kali-linux-2019.1a-amd64.iso"
             }
         },
         {
             "name": "2018.4",
             "images": {
+                "hda_disk_image": "kali-linux-persistence-1gb.qcow2",
                 "cdrom_image": "kali-linux-2018.4-amd64.iso"
             }
         },
         {
             "name": "2018.3a",
             "images": {
+                "hda_disk_image": "kali-linux-persistence-1gb.qcow2",
                 "cdrom_image": "kali-linux-2018.3a-amd64.iso"
             }
         },
         {
             "name": "2018.1",
             "images": {
+                "hda_disk_image": "kali-linux-persistence-1gb.qcow2",
                 "cdrom_image": "kali-linux-2018.1-amd64.iso"
             }
         },
         {
             "name": "2017.3",
             "images": {
+                "hda_disk_image": "kali-linux-persistence-1gb.qcow2",
                 "cdrom_image": "kali-linux-2017.3-amd64.iso"
             }
         },
         {
             "name": "2017.2",
             "images": {
+                "hda_disk_image": "kali-linux-persistence-1gb.qcow2",
                 "cdrom_image": "kali-linux-2017.2-amd64.iso"
             }
         },
         {
             "name": "2017.1",
             "images": {
+                "hda_disk_image": "kali-linux-persistence-1gb.qcow2",
                 "cdrom_image": "kali-linux-2017.1-amd64.iso"
             }
         },
         {
             "name": "2016.2",
             "images": {
+                "hda_disk_image": "kali-linux-persistence-1gb.qcow2",
                 "cdrom_image": "kali-linux-2016.2-amd64.iso"
             }
         },
         {
             "name": "2016.1",
             "images": {
+                "hda_disk_image": "kali-linux-persistence-1gb.qcow2",
                 "cdrom_image": "kali-linux-2016.1-amd64.iso"
             }
         },
         {
             "name": "2.0",
             "images": {
+                "hda_disk_image": "kali-linux-persistence-1gb.qcow2",
                 "cdrom_image": "kali-linux-2.0-amd64.iso"
             }
         }


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---

This PR adds the option to use persistence to Kali Linux. If the user selects ‘Live USB Persistence’ in the boot menu the changes are stored in a disk image. On the next boot with this boot option all the changes are still present. A short note in the usage tells about that. 

**This PR needs the image file "kali-linux-persistence-1gb.qcow2", downloadable from <https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/>. As I don't have the privileges to upload there, the maintainer has to do it. The image is temporarily available from <https://www.bernhard-ehlers.de/kali-linux-persistence-1gb.qcow2>**

Furthermore this PR made some minor changes:
- Put the default 2019.2 image on top and the MATE version second
- Corrected the download URL for the 2019.2 version
- Set ethernet interface names to eth{0}