### PR TITLE
Update the lastest cisco-iosvl2 image version up to v15.2.1

### DIFF
--- a/appliances/cisco-iosvl2.gns3a
+++ b/appliances/cisco-iosvl2.gns3a
@@ -23,6 +23,13 @@
         "kvm": "require"
     },
     "images": [
+	    {
+            "filename": "vios_l2-adventerprisek9-m.SSA.high_iron_20180619.qcow2",
+            "version": "15.2.1",
+            "md5sum": "14b981002e40b660f2d7400401e04c14",
+            "filesize": 44938752,
+            "download_url": "https://virl.mediuscorp.com/my-account/"
+        },
         {
             "filename": "vios_l2-adventerprisek9-m.03.2017.qcow2",
             "version": "15.2(20170321:233949)",
@@ -32,13 +39,19 @@
         },
         {
             "filename": "vios_l2-adventerprisek9-m.vmdk.SSA.152-4.0.55.E",
-            "version": "15.2.4055",
+            "version": "15.2(4055)E",
             "md5sum": "1a3a21f5697cae64bb930895b986d71e",
             "filesize": 96862208,
             "download_url": "https://virl.mediuscorp.com/my-account/"
         }
     ],
     "versions": [
+	     {
+            "name": "15.2.1",
+            "images": {
+                "hda_disk_image": "vios_l2-adventerprisek9-m.SSA.high_iron_20180619.qcow2"
+            }
+        },
         {
             "name": "15.2(20170321:233949)",
             "images": {
@@ -46,7 +59,7 @@
             }
         },
         {
-            "name": "15.2.4055",
+            "name": "15.2(20160506:4055)",
             "images": {
                 "hda_disk_image": "vios_l2-adventerprisek9-m.vmdk.SSA.152-4.0.55.E"
             }

--- a/appliances/cisco-iosvl2.gns3a
+++ b/appliances/cisco-iosvl2.gns3a
@@ -39,7 +39,7 @@
         },
         {
             "filename": "vios_l2-adventerprisek9-m.vmdk.SSA.152-4.0.55.E",
-            "version": "15.2(4055)E",
+            "version": "15.2(4.0.55)E",
             "md5sum": "1a3a21f5697cae64bb930895b986d71e",
             "filesize": 96862208,
             "download_url": "https://virl.mediuscorp.com/my-account/"
@@ -59,7 +59,7 @@
             }
         },
         {
-            "name": "15.2(20160506:4055)",
+            "name": "15.2(4.0.55)E",
             "images": {
                 "hda_disk_image": "vios_l2-adventerprisek9-m.vmdk.SSA.152-4.0.55.E"
             }


### PR DESCRIPTION
Update the lastest cisco-iosvl2 image version up to v15.2.1 on GNS3-registry. 
---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.