### PR TITLE
added FortiOS 6.2.1 and 6.2.2 to the Fortigate gns3a appliance template

### DIFF
--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -27,6 +27,18 @@
     },
     "images": [
         {
+            "filename": "FGT_VM64_KVM-v6-build1010-FORTINET.out.kvm.qcow2",
+            "version": "6.2.2",
+            "md5sum": "da411e21e4c0bc25553d0e72201af7a4",
+            "filesize": 58916864,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },{
+            "filename": "FGT_VM64_KVM-v6-build0932-FORTINET.out.kvm.qcow2",
+            "version": "6.2.1",
+            "md5sum": "725d41460ed1858dc905dbe2846a8400",
+            "filesize": 58785792,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },{
             "filename": "FGT_VM64_KVM-v6-build0866-FORTINET.out.kvm.qcow2",
             "version": "6.2.0",
             "md5sum": "588df9ba0db485976f6681810001ae73",
@@ -225,6 +237,20 @@
         }
     ],
     "versions": [
+        {
+            "name": "6.2.2",
+            "images": {
+                "hda_disk_image": "FGT_VM64_KVM-v6-build1010-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "6.2.1",
+            "images": {
+                "hda_disk_image": "FGT_VM64_KVM-v6-build0932-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
         {
             "name": "6.2.0",
             "images": {


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
everything is OK message recieved.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
