### PR TITLE
New releases, vSRX NIC type fix

### DIFF
--- a/appliances/fortisandbox.gns3a
+++ b/appliances/fortisandbox.gns3a
@@ -28,6 +28,13 @@
     },
     "images": [
         {
+            "filename": "FSA_KVM-v300-build0124-FORTINET.out.kvm.qcow2",
+            "version": "3.1.2",
+            "md5sum": "fc2b9a00d20063a6fa4103360d89a2d4",
+            "filesize": 186253824,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FSA_KVM-v300-build0060-FORTINET.out.kvm.qcow2",
             "version": "3.0.4",
             "md5sum": "7e744c4d62430917aea4533672710b5a",
@@ -106,6 +113,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "3.1.2",
+            "images": {
+                "hda_disk_image": "FSA_KVM-v300-build0124-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "FSA-datadrive.qcow2"
+            }
+        },
         {
             "name": "3.0.4",
             "images": {

--- a/appliances/fortisiem-super_worker.gns3a
+++ b/appliances/fortisiem-super_worker.gns3a
@@ -29,6 +29,27 @@
     },
     "images": [
         {
+            "filename": "FortiSIEM-VA-5.2.5.1615-OS.qcow2",
+            "version": "5.2.5",
+            "md5sum": "dfdc08a213bb80bf3f078869aeef6da6",
+            "filesize": 4412970903,
+            "download_url": "https://images-cdn.fortisiem.fortinet.com/VirtualAppliances/release510.html"
+        },
+        {
+            "filename": "FortiSIEM-VA-5.2.5.1615-CMDB.qcow2",
+            "version": "5.2.5",
+            "md5sum": "3963f0439c41d9efd33b7f5bda3f1c2d",
+            "filesize": 46858240,
+            "download_url": "https://images-cdn.fortisiem.fortinet.com/VirtualAppliances/release510.html"
+        },
+        {
+            "filename": "FortiSIEM-VA-5.2.5.1615-SVN.qcow2",
+            "version": "5.2.5",
+            "md5sum": "e90b2da5e2c7f2e338a822a448f326b2",
+            "filesize": 46858240,
+            "download_url": "https://images-cdn.fortisiem.fortinet.com/VirtualAppliances/release510.html"
+        },
+        {
             "filename": "FortiSIEM-VA-5.2.1.1553-OS.qcow2",
             "version": "5.2.1",
             "md5sum": "9dc3f4a9614b65c83d3e9733248cbcea",
@@ -135,6 +156,14 @@
         }
     ],
     "versions": [
+        {
+            "name": "5.2.5",
+            "images": {
+                "hda_disk_image": "FortiSIEM-VA-5.2.5.1615-OS.qcow2",
+                "hdb_disk_image": "FortiSIEM-VA-5.2.5.1615-CMDB.qcow2",
+                "hdc_disk_image": "FortiSIEM-VA-5.2.5.1615-SVN.qcow2"
+            }
+        },
         {
             "name": "5.2.1",
             "images": {

--- a/appliances/fortiweb.gns3a
+++ b/appliances/fortiweb.gns3a
@@ -27,6 +27,13 @@
     },
     "images": [
         {
+            "filename": "FWB_KVM-v600-build0727-FORTINET.out.kvm.qcow2",
+            "version": "6.2.1",
+            "md5sum": "05523a6db26030a8fc3d84e53902d162",
+            "filesize": 225313280,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FWB_KVM-v600-build0383-FORTINET.out.kvm.qcow2",
             "version": "6.1.0",
             "md5sum": "d2dbbde9f03eb716a54119cc3e6055c4",
@@ -114,6 +121,13 @@
 
     ],
     "versions": [
+        {
+            "name": "6.2.1",
+            "images": {
+                "hda_disk_image": "FWB_KVM-v600-build0727-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
         {
             "name": "6.1.0",
             "images": {

--- a/appliances/juniper-vmx-vcp.gns3a
+++ b/appliances/juniper-vmx-vcp.gns3a
@@ -26,6 +26,24 @@
     },
     "images": [
         {
+            "filename": "junos-vmx-x86-64-19.3R1.8.qcow2",
+            "version": "19.3R1.8-KVM",
+            "md5sum": "cd14a6884edeb6b337d3c2be02241c63",
+            "filesize": 1435238400
+        },
+        {
+            "filename": "vmxhdd-19.3R1.8.img",
+            "version": "19.3R1.8-KVM",
+            "md5sum": "ae26e0f32605a53a5c85342bad677c9f",
+            "filesize": 197120
+        },
+        {
+            "filename": "metadata-usb-re-19.3R1.8.img",
+            "version": "19.3R1.8-KVM",
+            "md5sum": "3c66c4657773a0cd2b38ffd84115446a",
+            "filesize": 10485760
+        },
+        {
             "filename": "junos-vmx-x86-64-17.4R1.16.qcow2",
             "version": "17.4R1.16-KVM",
             "md5sum": "85239193e852d643dfd9d5c257240bdf",
@@ -318,6 +336,14 @@
         }
     ],
     "versions": [
+        {
+            "name": "19.3R1.8-KVM",
+            "images": {
+                "hda_disk_image": "junos-vmx-x86-64-19.3R1.8.qcow2",
+                "hdb_disk_image": "vmxhdd-19.3R1.8.img",
+                "hdc_disk_image": "metadata-usb-re-19.3R1.8.img"
+            }
+        },
         {
             "name": "17.4R1.16-KVM",
             "images": {

--- a/appliances/juniper-vmx-vfp.gns3a
+++ b/appliances/juniper-vmx-vfp.gns3a
@@ -26,6 +26,13 @@
     },
     "images": [
         {
+            "filename": "vFPC-20190819.img",
+            "version": "19.3R1.8-KVM",
+            "md5sum": "b77ca27a45a07c56b8f72905fafbe822",
+            "filesize": 2447376384,
+            "download_url": "http://www.juniper.net/us/en/products-services/routing/mx-series/vmx/"
+        },
+        {
             "filename": "vFPC-20171213.img",
             "version": "17.4R1.16-KVM",
             "md5sum": "848a6256da7296e8fede368a258c68e4",
@@ -140,6 +147,12 @@
     ],
 
     "versions": [
+        {
+            "name": "19.3R1.8-KVM",
+            "images": {
+                "hda_disk_image": "vFPC-20190819.img"
+            }
+        },
         {
             "name": "17.4R1.16-KVM",
             "images": {

--- a/appliances/juniper-vqfx-pfe.gns3a
+++ b/appliances/juniper-vqfx-pfe.gns3a
@@ -25,8 +25,8 @@
     },
     "images": [
         {
-            "filename": "cosim_20180212.qcow2",
-            "version": "17.4R1",
+            "filename": "cosim-18.4R1.8_20180212.qcow2",
+            "version": "17.4R1 & 18.4R1",
             "md5sum": "0372e9c1b7df3608099186ab8cbbf2ad",
             "filesize": 1911291904,
             "download_url": "https://www.juniper.net/us/en/dm/free-vqfx-trial/"
@@ -41,9 +41,9 @@
     ],
     "versions": [
         {
-            "name": "17.4R1",
+            "name": "17.4R1 & 18.4R1",
             "images": {
-                "hda_disk_image": "cosim_20180212.qcow2"
+                "hda_disk_image": "cosim-18.4R1.8_20180212.qcow2"
             }
         },
         {

--- a/appliances/juniper-vqfx-re.gns3a
+++ b/appliances/juniper-vqfx-re.gns3a
@@ -25,6 +25,13 @@
     },
     "images": [
         {
+           "filename": "jinstall-vqfx-10-f-18.4R1.8.qcow2",
+           "version": "18.4R1",
+           "md5sum": "1b0dbd9a235f887e56a8506c0b2f684f",
+           "filesize": 549584896,
+           "download_url": "https://www.juniper.net/us/en/dm/free-vqfx-trial/"
+        },
+        {
            "filename": "jinstall-vqfx-10-f-17.4R1.16.img",
            "version": "17.4R1",
            "md5sum": "dd83313b0f5beaf68488ed3d5e1e5240",
@@ -40,6 +47,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "18.4R1",
+            "images": {
+                "hda_disk_image": "jinstall-vqfx-10-f-18.4R1.8.qcow2"
+            }
+        },
         {
             "name": "17.4R1",
             "images": {

--- a/appliances/juniper-vsrx.gns3a
+++ b/appliances/juniper-vsrx.gns3a
@@ -25,6 +25,13 @@
     },
     "images": [
         {
+            "filename": "junos-media-vsrx-x86-64-vmdisk-19.3R1.8.qcow2",
+            "version": "19.3R1",
+            "md5sum": "4121122ccf9ec697fd26cdac91b81543",
+            "filesize": 5185142784,
+            "download_url": "https://www.juniper.net/us/en/dm/free-vsrx-trial/"
+        },
+        {
             "filename": "junos-media-vsrx-vmdisk-18.1R1.9.qcow2",
             "version": "18.1R1",
             "md5sum": "4e9393142afc675d5d3d03c5071e70ce",
@@ -145,6 +152,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "19.3R1",
+            "images": {
+                "hda_disk_image": "junos-media-vsrx-x86-64-vmdisk-19.3R1.8.qcow2"
+            }
+        },
         {
             "name": "18.1R1",
             "images": {

--- a/appliances/juniper-vsrx.gns3a
+++ b/appliances/juniper-vsrx.gns3a
@@ -15,7 +15,7 @@
     "first_port_name": "fxp0",
     "port_name_format": "ge-0/0/{0}",
     "qemu": {
-        "adapter_type": "e1000",
+        "adapter_type": "virtio-net-pci",
         "adapters": 6,
         "ram": 4096,
         "arch": "x86_64",

--- a/appliances/juniper-vsrx.gns3a
+++ b/appliances/juniper-vsrx.gns3a
@@ -15,7 +15,7 @@
     "first_port_name": "fxp0",
     "port_name_format": "ge-0/0/{0}",
     "qemu": {
-        "adapter_type": "virtio-net-pci",
+        "adapter_type": "vmxnet3",
         "adapters": 6,
         "ram": 4096,
         "arch": "x86_64",

--- a/appliances/kali-linux.gns3a
+++ b/appliances/kali-linux.gns3a
@@ -23,6 +23,14 @@
     },
     "images": [
         {
+            "filename": "kali-linux-2019.3-amd64.iso",
+            "version": "2019.3",
+            "md5sum": "9c6fb00558f78ed06992d89f745ef975",
+            "filesize": 3037736960,
+            "download_url": "https://www.kali.org/downloads/",
+            "direct_download_url": "http://cdimage.kali.org/kali-2019.3/kali-linux-2019.3-amd64.iso"
+        },
+        {
             "filename": "kali-linux-2019.2-amd64.iso",
             "version": "2019.2",
             "md5sum": "0f89b6225d7ea9c18682f7cc541c1179",
@@ -128,6 +136,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "2019.3",
+            "images": {
+                "hda_disk_image": "kali-linux-persistence-1gb.qcow2",
+                "cdrom_image": "kali-linux-2019.3-amd64.iso"
+            }
+        },
         {
             "name": "2019.2",
             "images": {


### PR DESCRIPTION
Don't forget to merge and not re-base. ;)
---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
