### PR TITLE
Changed NIC type to virtio

### DIFF
--- a/appliances/juniper-vqfx-re.gns3a
+++ b/appliances/juniper-vqfx-re.gns3a
@@ -15,7 +15,7 @@
     "usage": "Initial username is root, password is Juniper (capitol J).\n\nUSAGE INSTRUCTIONS\n\nConnect the first interface (em0) to your admin VLAN. Connect the second interface (em1) directly to the second interface (em1) of the PFE. The switch ports connect here on the RE",
     "port_name_format": "em{0}",
     "qemu": {
-        "adapter_type": "e1000",
+        "adapter_type": "virtio-net-pci",
         "adapters": 12,
         "ram": 1024,
         "arch": "x86_64",


### PR DESCRIPTION
Though it doesn't solve the issues with 2.2.2, I'm sure the RE works with virtio.

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
