### PR TITLE
Added images 30.3 and 30.4

### DIFF
--- a/appliances/exos.gns3a
+++ b/appliances/exos.gns3a
@@ -11,7 +11,7 @@
     "maintainer": "Extreme Networks",
     "maintainer_email": "GitHubscripting@extremenetworks.com",
     "usage": "Boot up and login is admin with no password.",
-    "symbol": "ethernet_switch.svg",
+    "symbol": ":/symbols/multilayer_switch.svg",
     "first_port_name": "Mgmt",
     "port_name_format": "Port{port1}",
     "qemu": {
@@ -28,6 +28,20 @@
     
     "images": [
 
+		{
+            "filename": "EXOS-VM_v30.4.1.2.qcow2",
+            "version": "30.4.1.2",
+            "md5sum": "133fa38bf80daec9e389729c96e692c0",
+            "filesize": 454557696,
+            "direct_download_url": "https://akamai-ep.extremenetworks.com/Extreme_P/github-en/Virtual_EXOS/EXOS-VM_v30.4.1.2.qcow2"
+        },
+		{
+            "filename": "EXOS-VM_v30.3.1.6.qcow2",
+            "version": "30.3.1.6",
+            "md5sum": "edb86b406efe99434c6d5366d9bfa97f",
+            "filesize": 448266240,
+            "direct_download_url": "https://akamai-ep.extremenetworks.com/Extreme_P/github-en/Virtual_EXOS/EXOS-VM_v30.3.1.6.qcow2"
+        },
 		{
             "filename": "EXOS-VM_v30.2.1.8.qcow2",
             "version": "30.2.1.8",
@@ -62,6 +76,18 @@
     "versions": [
 
         {
+            "name": "30.4.1.2",
+            "images": {
+                "hda_disk_image": "EXOS-VM_v30.4.1.2.qcow2"
+            }
+        },
+		{
+            "name": "30.3.1.6",
+            "images": {
+                "hda_disk_image": "EXOS-VM_v30.3.1.6.qcow2"
+            }
+        },
+		{
             "name": "30.2.1.8",
             "images": {
                 "hda_disk_image": "EXOS-VM_v30.2.1.8.qcow2"
@@ -87,4 +113,3 @@
         }
     ]
 }
-


### PR DESCRIPTION
Added images 30.3 and 30.4 and fixed the "symbol" as it caused import errors.

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x ] The new version is on top.
- [x ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x ] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ x] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ x] GNS3 VM can run it without any tweaks.
  - [ x] The device is in the right category: router, switch, guest (hosts), firewall
  - [ x] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [x ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
