### PR TITLE
Updated Kali Linux docker image

### DIFF
--- a/docker/kalilinux/Dockerfile
+++ b/docker/kalilinux/Dockerfile
@@ -1,6 +1,6 @@
-FROM kalilinux/kali-linux-docker
+FROM kalilinux/kali-rolling
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends metasploit-framework nmap hydra sqlmap telnet openssh-client dnsutils yersinia ettercap-text-only cisco-global-exploiter cisco-auditing-tool snmp dsniff dnschef fping hping3 tshark python-scapy\
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y tshark && apt-get install -y --no-install-recommends metasploit-framework nmap hydra sqlmap telnet openssh-client dnsutils yersinia ettercap-text-only cisco-global-exploiter cisco-auditing-tool snmp dsniff dnschef fping hping3 python-scapy\
     && rm -rf /var/lib/apt/lists/*
 
 CMD /bin/bash 


### PR DESCRIPTION
The `kali-linux-docker` image was removed from Docker Hub, so I replaced the import to the new and updated Docker image `kali-rolling`.

The `tshark` program is installed separately because if it's installed along with the remaining programs, a prompt appears and the installation process freezes.

Before submitting a pull request, please check the following.
---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
