### PR TITLE
Updates and URL fixes.

### DIFF
--- a/appliances/cisco-csr1000v.gns3a
+++ b/appliances/cisco-csr1000v.gns3a
@@ -22,6 +22,13 @@
         "kvm": "require"
     },
     "images": [
+            {
+            "filename": "csr1000v-universalk9.16.12.03-serial.qcow2",
+            "version": "16.12.3",
+            "md5sum": "1fc380569ad3cc145fb9cbc993b2eb32",
+            "filesize": 986775552,
+            "download_url": "https://software.cisco.com/download/home/284364978/type/282046477/release/Gibraltar-16.12.3"
+        },
         {
             "filename": "csr1000v-universalk9.16.12.01a-serial.qcow2",
             "version": "16.12.1a",
@@ -36,6 +43,13 @@
             "filesize": 950468608,
             "download_url": "https://software.cisco.com/download/home/284364978/type/282046477/release/Gibraltar-16.10.1b"
         },
+        {
+            "filename": "csr1000v-universalk9.16.09.05-serial.qcow2",
+            "version": "16.9.5",
+            "md5sum": "7a07a182178243c1c107e68f04ecd8b5",
+            "filesize": 920518656,
+            "download_url": "https://software.cisco.com/download/home/284364978/type/282046477/release/Fuji-16.9.5"
+        },        
         {
             "filename": "csr1000v-universalk9.16.09.01-serial.qcow2",
             "version": "16.9.1",
@@ -58,11 +72,18 @@
             "download_url": "https://software.cisco.com/download/release.html?mdfid=284364978&flowid=39582&softwareid=282046477&release=Fuji-16.7.1"
         },
         {
+            "filename": "csr1000v-universalk9.16.06.07-serial.qcow2",
+            "version": "16.6.7",
+            "md5sum": "2aba82d78091b4603224a13710399447",
+            "filesize": 1573322752,
+            "download_url": "https://software.cisco.com/download/release.html?mdfid=284364978&flowid=39582&softwareid=282046477&release=Everest-16.6.7"
+        },        
+        {
             "filename": "csr1000v-universalk9.16.06.06-serial.qcow2",
             "version": "16.6.6",
             "md5sum": "31bd32ef6b0d83a8ca19c7b566737a36",
             "filesize": 1573191680,
-            "download_url": "https://software.cisco.com/download/release.html?mdfid=284364978&flowid=39582&softwareid=282046477&release=Everest-16.6.2"
+            "download_url": "https://software.cisco.com/download/release.html?mdfid=284364978&flowid=39582&softwareid=282046477&release=Everest-16.6.6"
         },
         {
             "filename": "csr1000v-universalk9.16.06.02-serial.qcow2",
@@ -130,6 +151,12 @@
     ],
     "versions": [
         {
+            "name": "16.12.3",
+            "images": {
+                "hda_disk_image": "csr1000v-universalk9.16.12.03-serial.qcow2"
+            }
+        },    
+        {
             "name": "16.12.1a",
             "images": {
                 "hda_disk_image": "csr1000v-universalk9.16.12.01a-serial.qcow2"
@@ -141,6 +168,12 @@
                 "hda_disk_image": "csr1000v-universalk9.16.10.01b-serial.qcow2"
             }
         },
+        {
+            "name": "16.9.5",
+            "images": {
+                "hda_disk_image": "csr1000v-universalk9.16.09.05-serial.qcow2"
+            }
+        },        
         {
             "name": "16.9.1",
             "images": {
@@ -159,6 +192,12 @@
                 "hda_disk_image": "csr1000v-universalk9.16.07.01-serial.qcow2"
             }
         },
+        {
+            "name": "16.6.7",
+            "images": {
+                "hda_disk_image": "csr1000v-universalk9.16.06.07-serial.qcow2"
+            }
+        },        
         {
             "name": "16.6.6",
             "images": {


### PR DESCRIPTION
Added 16.12.3, 16.9.5, and 16.6.7.
Fixed a download URL pointing to the wrong version.

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
