### PR TITLE
Update Appliance Kali Linux CLI

### DIFF
--- a/appliances/kali-linux-cli.gns3a
+++ b/appliances/kali-linux-cli.gns3a
@@ -12,6 +12,6 @@
     "maintainer_email": "developers@gns3.net",
     "docker": {
         "adapters": 2,
-        "image": "gns3/kalilinux:v2"
+        "image": "gns3/kalilinux:latest"
     }
 }


### PR DESCRIPTION
Docker Image `gns3/kalilinux:v2` does not exist, only kali docker image that exists is `gns3/kalilinux:latest`.

When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
