### PR TITLE
Update F5 BIG-IP and BIG-IQ versions

### DIFF
--- a/appliances/f5-bigip.gns3a
+++ b/appliances/f5-bigip.gns3a
@@ -28,11 +28,32 @@
     },
     "images": [
         {
+            "filename": "BIGIP-15.1.0.2-0.0.9.qcow2",
+            "version": "15.1.0.2",
+            "md5sum": "95ff618b7d0b53c4252299cd49b0e564",
+            "filesize": 5236588544,
+            "download_url": "https://downloads.f5.com/esd/serveDownload.jsp?path=/big-ip/big-ip_v15.x/15.1.0/english/15.1.0.2_virtual-edition/&sw=BIG-IP&pro=big-ip_v15.x&ver=15.1.0&container=15.1.0.2_Virtual-Edition&file=BIGIP-15.1.0.2-0.0.9.ALL.qcow2.zip"
+        },
+        {
+            "filename": "BIGIP-15.0.1.3-0.0.4.qcow2",
+            "version": "15.0.1.3",
+            "md5sum": "9caf1fb3e373ab37b9d489c038ff1908",
+            "filesize": 5236588544,
+            "download_url": "https://downloads.f5.com/esd/serveDownload.jsp?path=/big-ip/big-ip_v15.x/15.0.1/english/15.0.1.3_virtual-edition/&sw=BIG-IP&pro=big-ip_v15.x&ver=15.0.1&container=15.0.1.3_Virtual-Edition&file=BIGIP-15.0.1.3-0.0.4.ALL.qcow2.zip"
+        },
+        {
+            "filename": "BIGIP-15.0.0-0.0.39.qcow2",
+            "version": "15.0.0",
+            "md5sum": "978ede3addc717ff853e9d05dc0e9289",
+            "filesize": 5251923968,
+            "download_url": "https://downloads.f5.com/esd/serveDownload.jsp?path=/big-ip/big-ip_v15.x/15.0.0/english/virtual-edition/&sw=BIG-IP&pro=big-ip_v15.x&ver=15.0.0&container=Virtual-Edition&file=BIGIP-15.0.0-0.0.39.ALL.qcow2.zip"
+        },
+        {
             "filename": "BIGIP-14.1.2.3-0.0.5.qcow2",
             "version": "14.1.2.3",
-            "md5sum": "356520eedb615c93e985474f2b2ec603",
-            "filesize": 5036834816,
-            "download_url": "https://downloads.f5.com"
+            "md5sum": "a16fbbd264605460cf254d0f0fb7faad",
+            "filesize": 5110169600,
+            "download_url": "https://downloads.f5.com/esd/serveDownload.jsp?path=/big-ip/big-ip_v14.x/14.1.2/english/14.1.2.3_virtual-edition/&sw=BIG-IP&pro=big-ip_v14.x&ver=14.1.2&container=14.1.2.3_Virtual-Edition&file=BIGIP-14.1.2.3-0.0.5.ALL.qcow2.zip"
         },
         {
             "filename": "BIGIP-14.0.0.3-0.0.4.qcow2",
@@ -133,13 +154,6 @@
             "download_url": "https://downloads.f5.com/esd/serveDownload.jsp?path=/big-ip/big-ip_v11.x/11.6.0/english/virtual-edition/&sw=BIG-IP&pro=big-ip_v11.x&ver=11.6.0&container=Virtual-Edition&file=BIGIP-11.6.0.0.0.401.ALL.qcow2.zip"
         },
         {
-            "filename": "BIGIP-11.3.0.39.0.qcow2",
-            "version": "11.3.0",
-            "md5sum": "f3dec4565484fe81233077ab2ce426ae",
-            "filesize": 1842020352,
-            "download_url": "https://downloads.f5.com/esd/serveDownload.jsp?path=/big-ip/big-ip_v11.x/11.3.0/english/virtual-edition-trial/&sw=BIG-IP&pro=big-ip_v11.x&ver=11.3.0&container=Virtual-Edition-Trial&file=BIGIP-11.3.0.39.0.qcow2.zip"
-        },
-        {
             "filename": "empty100G.qcow2",
             "version": "1.0",
             "md5sum": "1e6409a4523ada212dea2ebc50e50a65",
@@ -149,6 +163,27 @@
         }
     ],
     "versions": [
+        {
+            "name": "15.1.0.2",
+            "images": {
+                "hda_disk_image": "BIGIP-15.1.0.2-0.0.9.qcow2",
+                "hdb_disk_image": "empty100G.qcow2"
+            }
+        },
+        {
+            "name": "15.0.1.3",
+            "images": {
+                "hda_disk_image": "BIGIP-15.0.1.3-0.0.4.qcow2",
+                "hdb_disk_image": "empty100G.qcow2"
+            }
+        },
+        {
+            "name": "15.0.0",
+            "images": {
+                "hda_disk_image": "BIGIP-15.0.0-0.0.39.qcow2",
+                "hdb_disk_image": "empty100G.qcow2"
+            }
+        },
         {
             "name": "14.1.2.3",
             "images": {
@@ -251,13 +286,6 @@
             "name": "11.6.0",
             "images": {
                 "hda_disk_image": "BIGIP-11.6.0.0.0.401.qcow2",
-                "hdb_disk_image": "empty100G.qcow2"
-            }
-        },
-        {
-            "name": "11.3.0",
-            "images": {
-                "hda_disk_image": "BIGIP-11.3.0.39.0.qcow2",
                 "hdb_disk_image": "empty100G.qcow2"
             }
         }

--- a/appliances/f5-bigiq.gns3a
+++ b/appliances/f5-bigiq.gns3a
@@ -30,11 +30,18 @@
     },
     "images": [
         {
-            "filename": "BIG-IQ-7.0.0.0.0.1854.qcow2",
-            "version": "7.0.0.0",
-            "md5sum": "89ff128c4ba82c266a6cefa21c80029b",
-            "filesize": 4312006656,
-            "download_url": "https://downloads.f5.com/esd/serveDownload.jsp?path=/big-iq/big-iq_cm/7.0.0/english/v7.0.0/&sw=BIG-IQ&pro=big-iq_CM&ver=7.0.0&container=v7.0.0&file=BIG-IQ-7.0.0.0.0.1854.qcow2.zip"
+            "filename": "BIG-IQ-7.1.0.0.0.1511.qcow2",
+            "version": "7.1.0.0",
+            "md5sum": "8d93b06e6eec656584a73ad16be6efa3",
+            "filesize": 4567072768,
+            "download_url": "https://downloads.f5.com/esd/serveDownload.jsp?path=/big-iq/big-iq_cm/7.1.0/english/v7.1.0/&sw=BIG-IQ&pro=big-iq_CM&ver=7.1.0&container=v7.1.0&file=BIG-IQ-7.1.0.0.0.1511.qcow2.zip"
+        },
+        {
+            "filename": "BIG-IQ-7.0.0.1.0.0.6.qcow2",
+            "version": "7.0.0.1",
+            "md5sum": "e86c851a1c43c8c0743f32742d97eba2",
+            "filesize": 4294246400,
+            "download_url": "https://downloads.f5.com/esd/serveDownload.jsp?path=/big-iq/big-iq_cm/7.0.0/english/v7.0.0.1/&sw=BIG-IQ&pro=big-iq_CM&ver=7.0.0&container=v7.0.0.1&file=BIG-IQ-7.0.0.1.0.0.6.qcow2.zip"
         },
         {
             "filename": "BIG-IQ-6.0.1.1.0.0.9.qcow2",
@@ -49,13 +56,6 @@
             "md5sum": "e3e6389438ba1e1676f507658f767e95",
             "filesize": 3480748032,
             "download_url": "https://downloads.f5.com/esd/serveDownload.jsp?path=/big-iq/big-iq_cm/5.4.0/english/virtual-edition_base-plus-hf2/&sw=BIG-IQ&pro=big-iq_CM&ver=5.4.0&container=Virtual-Edition_Base-Plus-HF2&file=BIG-IQ-5.4.0.2.24.7467.qcow2.zip"
-        },
-        {
-            "filename": "BIG-IQ-5.4.0.0.0.7437.qcow2",
-            "version": "5.4.0",
-            "md5sum": "068b1f4d21048b9b2a082c0c27ef4d53",
-            "filesize": 3300917248,
-            "download_url": "https://downloads.f5.com/esd/serveDownload.jsp?path=/big-iq/big-iq_cm/5.4.0/english/v5.4.0/&sw=BIG-IQ&pro=big-iq_CM&ver=5.4.0&container=v5.4.0&file=BIG-IQ-5.4.0.0.0.7437.qcow2.zip"
         },
         {
             "filename": "BIG-IQ-5.3.0.0.0.1119.qcow2",
@@ -103,9 +103,16 @@
     ],
     "versions": [
         {
-            "name": "7.0.0.0",
+            "name": "7.1.0.0",
             "images": {
-                "hda_disk_image": "BIG-IQ-7.0.0.0.0.1854.qcow2",
+                "hda_disk_image": "BIG-IQ-7.1.0.0.0.1511.qcow2",
+                "hdb_disk_image": "empty100G.qcow2"
+            }
+        },
+        {
+            "name": "7.0.0.1",
+            "images": {
+                "hda_disk_image": "BIG-IQ-7.0.0.1.0.0.6.qcow2",
                 "hdb_disk_image": "empty100G.qcow2"
             }
         },
@@ -120,13 +127,6 @@
             "name": "5.4.0.2",
             "images": {
                 "hda_disk_image": "BIG-IQ-5.4.0.2.24.7467.qcow2",
-                "hdb_disk_image": "empty100G.qcow2"
-            }
-        },
-        {
-            "name": "5.4.0",
-            "images": {
-                "hda_disk_image": "BIG-IQ-5.4.0.0.0.7437.qcow2",
                 "hdb_disk_image": "empty100G.qcow2"
             }
         },


### PR DESCRIPTION
Added BIG-IQ 7.1.0.0, 7.0.0.0 is no longer available for download so I've swapped it with 7.0.0.1. 5.4.0.2 is no longer available for download so its been removed. I tested BIG-IQ 7.1.0.0 with no issues.

Added BIG-IP v15.1.0.2, 15.0.1.3, and 15.0.0. Corrected filesize and m5sum for 14.1.2.3 as I had errors trying to import, fixed download URL as well. I removed 11.3 as its no longer available for download. I tested 15.1.0.2, and 14.1.2.3 with no issues.

check.py ran with no problems, output gave Everything is ok!

The diff on BIGIQ looks weird because of the line numbers changing but nothing else was modified except for the above.

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [X] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [X] GNS3 VM can run it without any tweaks.