### PR TITLE
Update Jupyter container.

### DIFF
--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.1
+FROM python:3.7.7
 
 RUN pip3 install jupyter
 

--- a/docker/jupyter/jupyter_notebook_config.py
+++ b/docker/jupyter/jupyter_notebook_config.py
@@ -1,2 +1,3 @@
 c.NotebookApp.token = ''
 c.NotebookApp.password = ''
+c.NotebookApp.ip = '0.0.0.0'


### PR DESCRIPTION
This Pull Request is related Issue #520.

GNS3 Jupyter container can't access console.
This PR is update Python3 from 3.6.1 to 3.7.7, and add `c.NotebookApp.ip = '0.0.0.0'` line in jupyter_notebook_config.py .

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
