### PR TITLE
Reduce image size of FRR appliance

### DIFF
--- a/appliances/frr.gns3a
+++ b/appliances/frr.gns3a
@@ -1,41 +1,39 @@
 {
     "name": "FRR",
     "category": "router",
-    "description": "FRRouting (FRR) is an IP routing protocol suite for Linux and Unix platforms which includes protocol daemons for BGP, IS-IS, LDP, OSPF, PIM, and RIP.\n\nFRR’s seamless integration with the native Linux/Unix IP networking stacks makes it applicable to a wide variety of use cases including connecting hosts/VMs/containers to the network, advertising network services, LAN switching and routing, Internet access routers, and Internet peering.\n\nThis is an unofficial VM or FRR.",
+    "description": "FRRouting (FRR) is an IP routing protocol suite for Linux and Unix platforms which includes protocol daemons for BGP, IS-IS, LDP, OSPF, PIM, and RIP.\n\nFRR’s seamless integration with the native Linux/Unix IP networking stacks makes it applicable to a wide variety of use cases including connecting hosts/VMs/containers to the network, advertising network services, LAN switching and routing, Internet access routers, and Internet peering.\n\nThis is an unofficial VM of FRR.",
     "vendor_name": "FRRouting Project",
     "vendor_url": "https://frrouting.org",
     "product_name": "FRR",
     "registry_version": 3,
     "status": "stable",
-    "maintainer": "Andras Dosztal",
+    "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
-    "usage": "Credentials: frradmin / frr\nIf you exit from the router CLI, you can get back by typing 'vtysh' to the console.",
-    "port_name_format": "ens{port3}",
+    "usage": "Credentials: root / root\nIf you exit from the router CLI, you can get back by typing 'vtysh' to the console.",
+    "port_name_format": "eth{0}",
     "qemu": {
-        "adapter_type": "virtio-net-pci",
+        "adapter_type": "e1000",
         "adapters": 8,
-        "ram": 512,
-        "hda_disk_interface": "virtio",
+        "ram": 256,
         "arch": "x86_64",
         "console_type": "telnet",
-        "kvm": "require"
+        "kvm": "allow"
     },
     "images": [
         {
-            "filename": "frr7.1-vm0.4.qcow2",
-            "version": "7.1 - VM0.4",
-            "md5sum": "08390f257203126e5edffb9710e47974",
-            "filesize": 2051801088,
-            "download_url": "https://sourceforge.net/projects/frr/files/",
-            "direct_download_url": "https://sourceforge.net/projects/frr/files/frr7.1-vm0.4.qcow2.bz2/download",
-            "compression": "bzip2"
+            "filename": "frr-7.3.1.qcow2",
+            "version": "7.3.1",
+            "md5sum": "5ed9434e6b87df86704145d77fb7d687",
+            "filesize": 47535104,
+            "download_url": "https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/",
+            "direct_download_url": "http://downloads.sourceforge.net/project/gns-3/Qemu%20Appliances/frr-7.3.1.qcow2"
         }
     ],
     "versions": [
         {
-            "name": "7.1 - VM0.4",
+            "name": "7.3.1",
             "images": {
-                "hda_disk_image": "frr7.1-vm0.4.qcow2"
+                "hda_disk_image": "frr-7.3.1.qcow2"
             }
         }
     ]

--- a/appliances/frr.gns3a
+++ b/appliances/frr.gns3a
@@ -23,8 +23,8 @@
         {
             "filename": "frr-7.3.1.qcow2",
             "version": "7.3.1",
-            "md5sum": "5ed9434e6b87df86704145d77fb7d687",
-            "filesize": 47535104,
+            "md5sum": "e6bd9591a5c630bfe2c8688dc043b20b",
+            "filesize": 47348224,
             "download_url": "https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/",
             "direct_download_url": "http://downloads.sourceforge.net/project/gns-3/Qemu%20Appliances/frr-7.3.1.qcow2"
         }

--- a/packer/alpine-linux/README.rst
+++ b/packer/alpine-linux/README.rst
@@ -5,10 +5,11 @@ For building an Alpine appliance.
 
 https://alpinelinux.org/
 
-CLI Linux installation
-**********************
+Alpine CLI installation
+***********************
 
 The only added packages are:
+
 * busybox-extras
 * nano
 
@@ -17,8 +18,18 @@ The only added packages are:
     packer build alpine_cli.json
 
 
-GUI Linux installation
-**********************
+FRR
+''''
+
+A build of Alpine with FRRouting preinstalled.
+
+.. code:: bash
+
+    packer build -var-file=frr.json alpine_cli.json
+
+
+Alpine GUI installation
+***********************
 
 The GUI version has XFCE4 installed.
 

--- a/packer/alpine-linux/frr.json
+++ b/packer/alpine-linux/frr.json
@@ -1,0 +1,4 @@
+{
+    "vm_name": "frr.qcow2",
+    "setup_script": "frr.sh"
+}

--- a/packer/alpine-linux/scripts/frr.sh
+++ b/packer/alpine-linux/scripts/frr.sh
@@ -18,12 +18,18 @@ cat > /root/set_hostname << 'EOF'
 #!/bin/sh
 
 if [ $# -ne 1 ]; then
-	echo "usage: set_hostname hostname" >&2
+	echo "usage: set_hostname host" >&2
 	exit 1
 fi
 
-hostname=$1
-domain=$(hostname -d)
+host=$1
+hostname=${host%%.*}
+if [ "$host" = "$hostname" ]; then
+	domain=$(hostname -d)
+else
+	domain=${host#*.}
+fi
+
 hostname "$hostname"
 echo "$hostname" > /etc/hostname
 sed -i -e "s/^127\.0\.0\.1.*/127.0.0.1\t${hostname}.${domain} ${hostname} localhost.localdomain localhost/" /etc/hosts
@@ -37,8 +43,11 @@ echo "service integrated-vtysh-config" > /etc/frr/vtysh.conf
 chown frr:frr /etc/frr/vtysh.conf
 
 # run vtysh in .profile
-cat > /root/.profile << EOF
+cat > /root/.profile << 'EOF'
 # ~/.profile: executed by Bourne-compatible login shells.
+
+# reset terminal modes
+[ -t 1 ] && printf '\e[?5l\e[?7h\e[?8h'
 
 if [ "$BASH" ]; then
   if [ -f ~/.bashrc ]; then

--- a/packer/alpine-linux/scripts/frr.sh
+++ b/packer/alpine-linux/scripts/frr.sh
@@ -1,0 +1,78 @@
+# add community repository
+sed -i 's/^#\(.*\/v.*\/community\)$/\1/' /etc/apk/repositories
+apk update
+
+# install packages
+apk add nano less busybox-extras
+apk add frr frr-openrc
+rc-update add frr
+
+# enable IP forwarding
+cat > /etc/sysctl.d/50-ip_forwarding.conf << EOF
+net.ipv4.conf.all.forwarding=1
+net.ipv6.conf.all.forwarding=1
+EOF
+
+# change hostname
+cat > /root/set_hostname << 'EOF'
+#!/bin/sh
+
+if [ $# -ne 1 ]; then
+	echo "usage: set_hostname hostname" >&2
+	exit 1
+fi
+
+hostname=$1
+domain=$(hostname -d)
+hostname "$hostname"
+echo "$hostname" > /etc/hostname
+sed -i -e "s/^127\.0\.0\.1.*/127.0.0.1\t${hostname}.${domain} ${hostname} localhost.localdomain localhost/" /etc/hosts
+EOF
+chmod +x /root/set_hostname
+/root/set_hostname frr
+
+# modify FRR configuration
+sed -i -E '/zebra|bgp|ospf|rip|isis|pim|ldp|eigrp|static|bfd/ s/= *no/=yes/' /etc/frr/daemons
+echo "service integrated-vtysh-config" > /etc/frr/vtysh.conf
+chown frr:frr /etc/frr/vtysh.conf
+
+# run vtysh in .profile
+cat > /root/.profile << EOF
+# ~/.profile: executed by Bourne-compatible login shells.
+
+if [ "$BASH" ]; then
+  if [ -f ~/.bashrc ]; then
+    . ~/.bashrc
+  fi
+fi
+
+mesg n || true
+
+export VTYSH_PAGER="less -M -i -EFX"
+vtysh
+EOF
+
+# network configuration
+cat > /etc/network/interfaces << EOF
+#
+# This is a sample network config, uncomment lines to configure the network
+#
+# Loopback interface
+auto lo
+iface lo inet loopback
+# Static config for eth0
+#auto eth0
+#iface eth0 inet static
+#	address 192.168.0.2
+#	netmask 255.255.255.0
+#	gateway 192.168.0.1
+#	up echo nameserver 192.168.0.1 > /etc/resolv.conf
+
+# DHCP config for eth0
+#auto eth0
+#iface eth0 inet dhcp
+#	hostname $(hostname)
+EOF
+
+cat > /etc/resolv.conf << EOF
+EOF

--- a/packer/alpine-linux/scripts/serial.sh
+++ b/packer/alpine-linux/scripts/serial.sh
@@ -2,4 +2,4 @@
 sed -i 's/\(APPEND .*\)/\1 console=ttyS0/' /boot/extlinux.conf
 
 # autologin on serial console
-sed -i 's/^#* *ttyS0.*/ttyS0::respawn:\/bin\/login -f root/' /etc/inittab
+sed -i 's/^ttyS0.*/ttyS0::respawn:\/bin\/login -f root/' /etc/inittab

--- a/packer/alpine-linux/scripts/setup.sh
+++ b/packer/alpine-linux/scripts/setup.sh
@@ -20,8 +20,8 @@ iface lo inet loopback
 #	up echo nameserver 192.168.0.1 > /etc/resolv.conf
 
 # DHCP config for eth0
-# auto eth0
-# iface eth0 inet dhcp
+#auto eth0
+#iface eth0 inet dhcp
 #	hostname $(hostname)
 EOF
 

--- a/packer/alpine-linux/scripts/setup.sh
+++ b/packer/alpine-linux/scripts/setup.sh
@@ -1,6 +1,27 @@
 # install additional packages
 apk add nano busybox-extras
 
+# create .profile
+cat > /root/.profile << 'EOF'
+# ~/.profile: executed by Bourne-compatible login shells.
+
+# reset terminal modes
+[ -t 1 ] && printf '\e[?5l\e[?7h\e[?8h'
+
+if [ "$BASH" ]; then
+  if [ -f ~/.bashrc ]; then
+    . ~/.bashrc
+  fi
+fi
+
+mesg n || true
+EOF
+
+find /home -type d -mindepth 1 -maxdepth 1 | while read -r home; do
+	cp -p /root/.profile "$home/"
+	chown $(stat -c '%u:%g' "$home") "$home/.profile"
+done
+
 # network configuration
 cat > /etc/network/interfaces << EOF
 #


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---

The current version of the FRR appliance works pretty well, but it has one main drawback: It's way too big, 717MB compressed / 2052MB uncompressed. Therefore I created a version based on alpine. It's FRR image is only 48MB "big".

I would prefer to have both versions in the appliance, but the alpine version uses network interfaces named eth0, eth1 ..., so I had to create a new one.

@adosztal It would be nice, when you would comment on this new version.

By default I enabled only the the more commonly used protocols bgp, ospf, ospf6, rip, ripng, isis, pim, ldp, eigrp, static, bfd. If the user needs the other more exotic routing protocols he has to enable it by editing the FRR configuration.

As the packer script is under the control of the GNS3 devs, I set the image location to <http://downloads.sourceforge.net/project/gns-3/Qemu%20Appliances/frr-7.3.1.qcow2>. @grossmj , please check if that location is fine, if not change it.

As I can't up upload to that location, I put it temporarily in <https://www.b-ehlers.de/tmp/frr-7.3.1.qcow2>, @grossmj **please upload it to the final location.**