### PR TITLE
Add new version of vMX images 20.2R1.10

### DIFF
--- a/appliances/juniper-vmx-vcp.gns3a
+++ b/appliances/juniper-vmx-vcp.gns3a
@@ -28,6 +28,24 @@
         "options": "-nographic -enable-kvm"
     },
     "images": [
+		{
+            "filename": "junos-vmx-x86-64-20.2R1.10.qcow2",
+            "version": "20.2R1.10-KVM",
+            "md5sum": "182484474accf07bd403ef17fa2959a9",
+            "filesize": 1413349376
+        },
+        {
+            "filename": "vmxhdd-20.2R1.10.img",
+            "version": "20.2R1.10-KVM",
+            "md5sum": "ae26e0f32605a53a5c85342bad677c9f",
+            "filesize": 197120
+        },
+        {
+            "filename": "metadata-usb-re-20.2R1.10.img",
+            "version": "20.2R1.10-KVM",
+            "md5sum": "25322c2caf542059de72e9adbec1fb68",
+            "filesize": 10485760
+        },
         {
             "filename": "junos-vmx-x86-64-19.3R1.8.qcow2",
             "version": "19.3R1.8-KVM",
@@ -339,6 +357,14 @@
         }
     ],
     "versions": [
+		{
+            "name": "20.2R1.10-KVM",
+            "images": {
+                "hda_disk_image": "junos-vmx-x86-64-20.2R1.10.qcow2",
+                "hdb_disk_image": "vmxhdd-20.2R1.10.img",
+                "hdc_disk_image": "metadata-usb-re-20.2R1.10.img"
+            }
+        },
         {
             "name": "19.3R1.8-KVM",
             "images": {

--- a/appliances/juniper-vmx-vfp.gns3a
+++ b/appliances/juniper-vmx-vfp.gns3a
@@ -26,6 +26,13 @@
         "options": "-nographic -enable-kvm -smp cpus=3"
     },
     "images": [
+		{
+            "filename": "vFPC-20200526.img",
+            "version": "20.2R1.10-KVM",
+            "md5sum": "400652d7e450b0bf8ad4cc37db46b78c",
+            "filesize": 2447376384,
+            "download_url": "http://www.juniper.net/us/en/products-services/routing/mx-series/vmx/"
+        },
         {
             "filename": "vFPC-20190819.img",
             "version": "19.3R1.8-KVM",
@@ -147,6 +154,12 @@
         }
     ],
     "versions": [
+		{
+            "name": "20.2R1.10-KVM",
+            "images": {
+                "hda_disk_image": "vFPC-20200526.img"
+            }
+        },
         {
             "name": "19.3R1.8-KVM",
             "images": {


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [x] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [x] GNS3 VM can run it without any tweaks.
  - [x] The device is in the right category: router, switch, guest (hosts), firewall
  - [x] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [x] When adding a container: it builds on Docker Hub and can be pulled.
- [x] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [x] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
