### PR TITLE
Add Cumulus VX 4.3.0, update usage, increase RAM

### DIFF
--- a/appliances/cumulus-vx.gns3a
+++ b/appliances/cumulus-vx.gns3a
@@ -11,19 +11,27 @@
     "status": "stable",
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
-    "usage": "Default username is cumulus and password is CumulusLinux!",
+    "usage": "Default username is cumulus and password is CumulusLinux! in version 4.1 and earlier, and cumulus in version 4.2 and later.",
     "first_port_name": "eth0",
     "port_name_format": "swp{port1}",
     "qemu": {
         "adapter_type": "virtio-net-pci",
         "adapters": 7,
-        "ram": 512,
+        "ram": 768,
         "hda_disk_interface": "ide",
         "arch": "x86_64",
         "console_type": "telnet",
         "kvm": "require"
     },
     "images": [
+        {
+          "filename": "cumulus-linux-4.3.0-vx-amd64-qemu.qcow2",
+          "version": "4.3.0",
+          "md5sum": "aba2f0bb462b26a208afb6202bc97d51",
+          "filesize": 2819325952,
+          "download_url": "https://cumulusnetworks.com/cumulus-vx/download/",
+          "direct_download_url": "https://d2cd9e7ca6hntp.cloudfront.net/public/CumulusLinux-4.3.0/cumulus-linux-4.3.0-vx-amd64-qemu.qcow2"
+        },
         {
             "filename": "cumulus-linux-4.2.0-vx-amd64-qemu.qcow2",
             "version": "4.2.0",
@@ -222,6 +230,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "4.3.0",
+            "images": {
+              "hda_disk_image": "cumulus-linux-4.3.0-vx-amd64-qemu.qcow2"
+            }
+        },
         {
             "name": "4.2.0",
             "images": {


### PR DESCRIPTION
This PR

* Adds the latest `Cumulus VX` image version `4.3.0`
* Mentions different default login credentials depending on the version, see [What is the Default User Name and Password in Cumulus Linux? – Cumulus Networks® Knowledge Base](https://support.cumulusnetworks.com/hc/en-us/articles/201787646-What-is-the-Default-User-Name-and-Password-in-Cumulus-Linux-)
* Increases RAM for versions `>= 4` are not usable with 512M RAM, per [this note RE system requirements](https://docs.cumulusnetworks.com/cumulus-vx/KVM-QEMU/#create-the-vms-and-network-connections) 768M is the minimum.
---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.