### PR TITLE
Add the latest versions of Fortinet devices

### DIFF
--- a/appliances/fortianalyzer.gns3a
+++ b/appliances/fortianalyzer.gns3a
@@ -17,7 +17,7 @@
     "qemu": {
         "adapter_type": "e1000",
         "adapters": 4,
-        "ram": 1024,
+        "ram": 4096,
         "hda_disk_interface": "virtio",
         "hdb_disk_interface": "virtio",
         "arch": "x86_64",
@@ -26,6 +26,13 @@
         "kvm": "allow"
     },
     "images": [
+        {
+            "filename": "FAZ_VM64_KVM-v6-build2288-FORTINET.out.kvm.qcow2",
+            "version": "6.4.5",
+            "md5sum": "e220b48c6e86f8ddc660d578295051a9",
+            "filesize": 152698880,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
         {
             "filename": "FAZ_VM64_KVM-v6-build1183-FORTINET.out.kvm.qcow2",
             "version": "6.2.2",
@@ -169,6 +176,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "6.4.5",
+            "images": {
+              "hda_disk_image": "FAZ_VM64_KVM-v6-build2288-FORTINET.out.kvm.qcow2",
+              "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
         {
             "name": "6.2.2",
             "images": {

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -27,6 +27,13 @@
     },
     "images": [
         {
+            "filename": "FGT_VM64_KVM-v6-build1828-FORTINET.out.kvm.qcow2",
+            "version": "6.4.5",
+            "md5sum": "dc064e16fa65461183544d8ddb5d19d9",
+            "filesize": 36175872,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FGT_VM64_KVM-v6-build1010-FORTINET.out.kvm.qcow2",
             "version": "6.2.2",
             "md5sum": "da411e21e4c0bc25553d0e72201af7a4",
@@ -246,6 +253,13 @@
         }
     ],
     "versions": [
+        {
+          "name": "6.4.5",
+          "images": {
+            "hda_disk_image": "FGT_VM64_KVM-v6-build1828-FORTINET.out.kvm.qcow2",
+            "hdb_disk_image": "empty30G.qcow2"
+          }
+        },
         {
             "name": "6.2.2",
             "images": {

--- a/appliances/fortimanager.gns3a
+++ b/appliances/fortimanager.gns3a
@@ -17,7 +17,7 @@
     "qemu": {
         "adapter_type": "virtio-net-pci",
         "adapters": 4,
-        "ram": 1024,
+        "ram": 2048,
         "hda_disk_interface": "virtio",
         "hdb_disk_interface": "virtio",
         "arch": "x86_64",
@@ -26,6 +26,20 @@
         "kvm": "allow"
     },
     "images": [
+        {
+            "filename": "FMG_VM64_KVM-v6-build2288-FORTINET.out.kvm.qcow2",
+            "version": "6.4.5",
+            "md5sum": "bd2791984b03f55a6825297e83c6576a",
+            "filesize": 117014528,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FMG_VM64_KVM-v6-build2253-FORTINET.out.kvm.qcow2",
+            "version": "6.4.4",
+            "md5sum": "3554a47fde2dc91d17eec16fd0dc10a3",
+            "filesize": 116621312,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
         {
             "filename": "FMG_VM64_KVM-v6-build1183-FORTINET.out.kvm.qcow2",
             "version": "6.2.2",
@@ -162,6 +176,20 @@
         }
     ],
     "versions": [
+        {
+            "name": "6.4.5",
+            "images": {
+              "hda_disk_image": "FMG_VM64_KVM-v6-build2288-FORTINET.out.kvm.qcow2",
+              "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "6.4.4",
+            "images": {
+              "hda_disk_image": "FMG_VM64_KVM-v6-build2253-FORTINET.out.kvm.qcow2",
+              "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
         {
             "name": "6.2.2",
             "images": {


### PR DESCRIPTION
This PR add the latest versions of Fortinet devices

- FortiGate version 6.4.5
- FortiManager versions 6.4.4, 6.4.5
- FortiAnalyzer version 6.4.5

Increased RAM because the latest images of FortiManager and FortiAnalyzer were
unable to boot with the current RAM specs.

---
When updating an **existing** appliance:
- [ x ] The new version is on top.
- [ x ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ x ] If you forked the repo, running check.py doesn't drop any errors for the updated file.