### PR TITLE
New appliance: mcjoin; new release: DANOS

### DIFF
--- a/appliances/danos.gns3a
+++ b/appliances/danos.gns3a
@@ -11,29 +11,29 @@
     "status": "stable",
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
-    "usage": "Default username/password is vyatta/vyatta.  DANOS will live boot and drop into a shell. DANOS can then be installed inside the VM by typing install image.  Defaults to using a telnet console, but the vnc console can provide additional help if it's not booting.",
+    "usage": "Default username / password is tmpuser / tmppwd.  DANOS will live boot and drop into a shell. DANOS can then be installed inside the VM by typing install image.  Defaults to using a telnet console, but the vnc console can provide additional help if it's not booting.",
     "symbol": ":/symbols/affinity/circle/gray/router_cloud.svg",
     "port_name_format": "dp0p{1}s{0}",
     "qemu": {
         "adapter_type": "virtio-net-pci",
-        "adapters": 3,
+        "adapters": 8,
         "ram": 4096,
-        "cpus": 2,
+        "cpus": 4,
         "hda_disk_interface": "ide",
         "arch": "x86_64",
         "console_type": "telnet",
-        "boot_priority": "dc",
-        "kvm": "allow",
+        "boot_priority": "cd",
+        "kvm": "require",
         "options": "-cpu host"
     },
     "images": [
         {
-            "filename": "danos-1908-amd64-vrouter.iso",
-            "version": "1908",
-            "md5sum": "e850b6aa2859de1075c11b9149fa50f4",
-            "filesize": 409993216,
-            "download_url": "https://danosproject.atlassian.net/wiki/spaces/DAN/pages/753667/DANOS+1908",
-            "direct_download_url": "http://repos.danosproject.org.s3-website-us-west-1.amazonaws.com/images/danos-1908-amd64-vrouter.iso"
+            "filename": "danos-2012-base-amd64.iso",
+            "version": "2012",
+            "md5sum": "fb7a60dc9afecdb274464832b3ab1ccb",
+            "filesize": 441450496,
+            "download_url": "https://danosproject.atlassian.net/wiki/spaces/DAN/pages/892141595/DANOS+2012",
+            "direct_download_url": "https://s3-us-west-1.amazonaws.com/2012.repos.danosproject.org/2012/iso/danos-2012-base-amd64.iso"
         },
         {
             "filename": "empty8G.qcow2",
@@ -46,10 +46,10 @@
     ],
     "versions": [
         {
-            "name": "1908",
+            "name": "2012",
             "images": {
                 "hda_disk_image": "empty8G.qcow2",
-                "cdrom_image": "danos-1908-amd64-vrouter.iso"
+                "cdrom_image": "danos-2012-base-amd64.iso"
             }
         }
     ]

--- a/appliances/danos.gns3a
+++ b/appliances/danos.gns3a
@@ -13,7 +13,7 @@
     "maintainer_email": "developers@gns3.net",
     "usage": "Default username / password is tmpuser / tmppwd.  DANOS will live boot and drop into a shell. DANOS can then be installed inside the VM by typing install image.  Defaults to using a telnet console, but the vnc console can provide additional help if it's not booting.",
     "symbol": ":/symbols/affinity/circle/gray/router_cloud.svg",
-    "port_name_format": "dp0p{1}s{0}",
+    "port_name_format": "dp0s{3}",
     "qemu": {
         "adapter_type": "virtio-net-pci",
         "adapters": 8,

--- a/appliances/mcjoin.gns3a
+++ b/appliances/mcjoin.gns3a
@@ -1,0 +1,18 @@
+{
+    "name": "mcjoin",
+    "category": "guest",
+    "description": "mcjoin is a very simple and easy-to-use tool to test IPv4 and IPv6 multicast.",
+    "vendor_name": "Joachim Nilsson",
+    "vendor_url": "https://github.com/troglobit",
+    "product_name": "mcjoin",
+    "registry_version": 3,
+    "status": "stable",
+    "maintainer": "GNS3 Team",
+    "maintainer_email": "developers@gns3.net",
+    "symbol": "linux_guest.svg",
+    "docker": {
+        "adapters": 1,
+        "image": "troglobit/mcjoin:latest",
+        "console_type": "telnet"
+    }
+}


### PR DESCRIPTION
The container mcjoin is a great tool to test multicast routing. I replaced the DANOS version with a new one because the one in the previous image was too old.

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [X] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [X] GNS3 VM can run it without any tweaks.
  - [X] The device is in the right category: router, switch, guest (hosts), firewall
  - [X] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [X] When adding a container: it builds on Docker Hub and can be pulled.
- [X] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [X] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
