### PR TITLE
fix adapter names

### DIFF
--- a/appliances/openbsd.gns3a
+++ b/appliances/openbsd.gns3a
@@ -11,7 +11,7 @@
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
     "usage": "User root, password gns3",
-    "first_port_name": "fxp0",
+    "first_port_name": "em0",
     "port_name_format": "em{0}",
     "qemu": {
         "adapter_type": "e1000",


### PR DESCRIPTION
When connecting devices in the GNS3 client, adapter names incorrectly show as "fxp0", "em0", "em1"..."em6"  when they should read "em0"..."em7".

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ ] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
