### PR TITLE
Update to permit new vios_l2 image

### DIFF
--- a/appliances/cisco-iosvl2.gns3a
+++ b/appliances/cisco-iosvl2.gns3a
@@ -23,6 +23,13 @@
         "kvm": "require"
     },
     "images": [
+	    {
+            "filename": "vios_l2-adventerprisek9-m.ssa.high_iron_20200929.qcow2",
+            "version": "15.2(20200924:215240)",
+            "md5sum": "99ecab32de12410c533e6abd4e9710aa",
+            "filesize": 90409984,
+            "download_url": "https://learningnetworkstore.cisco.com/myaccount"
+        },
         {
             "filename": "vios_l2-adventerprisek9-m.ssa.high_iron_20190423.qcow2",
             "version": "15.2(6.0.81)E",
@@ -53,6 +60,12 @@
         }
     ],
     "versions": [
+	    {
+            "name": "15.2(20200924:215240)",
+            "images": {
+                "hda_disk_image": "vios_l2-adventerprisek9-m.ssa.high_iron_20200929.qcow2"
+            }
+        },
         {
             "name": "15.2(6.0.81)E",
             "images": {


### PR DESCRIPTION
new vios_l2-adventerprisek9-m.ssa.high_iron_20200929.qcow2 image

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ ] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [x] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [x] GNS3 VM can run it without any tweaks.
  - [x] The device is in the right category: router, switch, guest (hosts), firewall
  - [x] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
