### PR TITLE
Add Rocky Linux v8.4

### DIFF
--- a/appliances/rockylinux.gns3a
+++ b/appliances/rockylinux.gns3a
@@ -1,0 +1,45 @@
+{
+    "name": "RockyLinux",
+    "category": "guest",
+    "description": "Rocky Linux is a community enterprise operating system designed to be 100% bug-for-bug compatible with Red Hat Enterprise Linux (RHEL).",
+    "vendor_name": "Rocky Enterprise Software Foundation",
+    "vendor_url": "https://rockylinux.org",
+    "documentation_url": "https://docs.rockylinux.org",
+    "product_name": "Rocky Linux",
+    "registry_version": 4,
+    "status": "experimental",
+    "maintainer": "Bernhard Ehlers",
+    "maintainer_email": "none@b-ehlers.de",
+    "usage": "Username:\trockylinux\nPassword:\trockylinux\nTo become root, use \"sudo su\".\n\nTo improve performance, increase RAM and vCPUs in the VM settings.",
+    "symbol": "linux_guest.svg",
+    "port_name_format": "ens{port4}",
+    "qemu": {
+        "adapter_type": "virtio-net-pci",
+        "adapters": 1,
+        "ram": 1536,
+        "hda_disk_interface": "sata",
+        "arch": "x86_64",
+        "console_type": "vnc",
+        "kvm": "require",
+        "options": "-usbdevice tablet"
+    },
+    "images": [
+        {
+            "filename": "RockyLinux_8.4_VMG_LinuxVMImages.COM.vmdk",
+            "version": "8.4",
+            "md5sum": "3452d5b0fbb4cdcf3ac6fe8de8d0ac08",
+            "filesize": 5273878528,
+            "download_url": "https://www.linuxvmimages.com/images/rockylinux-8",
+            "direct_download_url": "https://sourceforge.net/projects/linuxvmimages/files/VMware/R/rockylinux/8/RockyLinux_8.4_VMM.7z/download",
+            "compression": "7z"
+        }
+    ],
+    "versions": [
+        {
+            "name": "8.4",
+            "images": {
+                "hda_disk_image": "RockyLinux_8.4_VMG_LinuxVMImages.COM.vmdk"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This adds Rocky Linux v8.4, a community enterprise operating system compatible with Red Hat Enterprise Linux (RHEL).

The image was built by linuxvmimages.com and will be downloaded from SourceForge.

Username: rockylinux
Password: rockylinux
To become root, use "sudo su".

---

Before submitting a pull request, please check the following.

---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [x] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [x] GNS3 VM can run it without any tweaks.
  - [x] The device is in the right category: router, switch, guest (hosts), firewall
  - [x] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [x] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [x] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
