### PR TITLE
vyos - add v1.3.0-rc6

### DIFF
--- a/appliances/vyos.gns3a
+++ b/appliances/vyos.gns3a
@@ -11,7 +11,7 @@
     "status": "stable",
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
-    "usage": "Default username/password is vyos/vyos.\n\nAt first boot of versions 1.1.x/1.2.x the router will start from the cdrom. Login and then type \"install image\" and follow the instructions.",
+    "usage": "Default username/password is vyos/vyos.\n\nAt first boot the router will start from the cdrom. Login and then type \"install image\" and follow the instructions.",
     "symbol": "vyos.svg",
     "port_name_format": "eth{0}",
     "qemu": {
@@ -26,11 +26,12 @@
     },
     "images": [
         {
-            "filename": "vyos-1.3.0-rc5-amd64.qcow2",
-            "version": "1.3.0-rc5",
-            "md5sum": "dd704f59afc0fccdf601cc750bf2c438",
-            "filesize": 361955328,
-            "direct_download_url": "https://www.mediafire.com/file/taspgxh4vj0a4j1/vyos-1.3.0-rc5-amd64.qcow2/file"
+            "filename": "vyos-1.3.0-rc6-amd64.iso",
+            "version": "1.3.0-rc6",
+            "md5sum": "b3939f82a35b23d428ee0ad4ac8be087",
+            "filesize": 331350016,
+            "download_url": "https://vyos.net/get/snapshots/",
+            "direct_download_url": "https://s3.amazonaws.com/s3-us.vyos.io/snapshot/vyos-1.3.0-rc6/vyos-1.3.0-rc6-amd64.iso"
         },
         {
             "filename": "vyos-1.2.8-amd64.iso",
@@ -65,9 +66,10 @@
     ],
     "versions": [
         {
-            "name": "1.3.0-rc5",
+            "name": "1.3.0-rc6",
             "images": {
-                "hda_disk_image": "vyos-1.3.0-rc5-amd64.qcow2"
+                "hda_disk_image": "empty8G.qcow2",
+                "cdrom_image": "vyos-1.3.0-rc6-amd64.iso"
             }
         },
         {


### PR DESCRIPTION
The version 1.3.0-rc6 has be announced as the final release candidate for 1.3. So this should be the last image of v1.3, that is freely available. All the regular releases of vyos need a paid subscription.

Furthermore I went back to offer only official images. My self made qcow2 images are nice, but can't be verified by a third party.

@grossmj I suggest, that you check the appliances with check.py after merging them. Currently Nokia vSIM.gns3a and open-media-vault.gns3 don't meet the requirements of check.py.

---

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---