### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/docker/jupyter-2.7/Dockerfile
+++ b/docker/jupyter-2.7/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:2.7
 
-RUN pip install jupyter
+RUN pip install --no-cache-dir jupyter
 
 ADD jupyter_notebook_config.py /root/.jupyter/jupyter_notebook_config.py
 

--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7.7
 
-RUN pip3 install jupyter
+RUN pip3 install --no-cache-dir jupyter
 
 ADD jupyter_notebook_config.py /root/.jupyter/jupyter_notebook_config.py
 

--- a/docker/network_automation/Dockerfile
+++ b/docker/network_automation/Dockerfile
@@ -9,9 +9,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y --no-install-rec
     && apt-add-repository -y ppa:ansible/ansible-2.8 \
     && apt-get update && apt-get -y --no-install-recommends install ansible \
     && rm -rf /var/lib/apt/lists/* \
-    && pip3 install wheel \
-    && pip3 install cryptography netmiko napalm pyntc \
-    && pip3 install --upgrade paramiko && mkdir /scripts \
+    && pip3 install --no-cache-dir wheel \
+    && pip3 install --no-cache-dir cryptography netmiko napalm pyntc \
+    && pip3 install --no-cache-dir --upgrade paramiko && mkdir /scripts \
     && mkdir /root/.ssh/ \
     && echo "KexAlgorithms diffie-hellman-group1-sha1,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1" > /root/.ssh/config \
     && echo "Ciphers 3des-cbc,blowfish-cbc,aes128-cbc,aes128-ctr,aes256-ctr" >> /root/.ssh/config \

--- a/docker/network_automation_pycharm/Dockerfile
+++ b/docker/network_automation_pycharm/Dockerfile
@@ -34,11 +34,11 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     software-properties-common \
     && apt-add-repository -y ppa:ansible/ansible \
     && apt-get update && apt-get -y --no-install-recommends install ansible \
-    && pip install --upgrade pip \
-    && pip install cryptography netmiko napalm pyntc \
-    && pip install --upgrade paramiko \
-    && pip install pexpect \
-    && pip install docopt==0.6.2 sh
+    && pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir cryptography netmiko napalm pyntc \
+    && pip install --no-cache-dir --upgrade paramiko \
+    && pip install --no-cache-dir pexpect \
+    && pip install --no-cache-dir docopt==0.6.2 sh
 
 RUN export JAVA_HOME=/usr/lib/jvm/default-java
 


### PR DESCRIPTION
using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>