### PR TITLE
vyos - add v1.3.0-epa1

### DIFF
--- a/appliances/vyos.gns3a
+++ b/appliances/vyos.gns3a
@@ -26,12 +26,12 @@
     },
     "images": [
         {
-            "filename": "vyos-1.3.0-rc6-amd64.iso",
-            "version": "1.3.0-rc6",
-            "md5sum": "b3939f82a35b23d428ee0ad4ac8be087",
+            "filename": "vyos-1.3.0-epa1-amd64.iso",
+            "version": "1.3.0-epa1",
+            "md5sum": "a2aaa5bd3bc5827909d07a18a9de80a7",
             "filesize": 331350016,
             "download_url": "https://vyos.net/get/snapshots/",
-            "direct_download_url": "https://s3.amazonaws.com/s3-us.vyos.io/snapshot/vyos-1.3.0-rc6/vyos-1.3.0-rc6-amd64.iso"
+            "direct_download_url": "https://s3.amazonaws.com/s3-us.vyos.io/snapshot/vyos-1.3.0-epa1/generic-iso/vyos-1.3.0-epa1-amd64.iso"
         },
         {
             "filename": "vyos-1.2.8-amd64.iso",
@@ -66,10 +66,10 @@
     ],
     "versions": [
         {
-            "name": "1.3.0-rc6",
+            "name": "1.3.0-epa1",
             "images": {
                 "hda_disk_image": "empty8G.qcow2",
-                "cdrom_image": "vyos-1.3.0-rc6-amd64.iso"
+                "cdrom_image": "vyos-1.3.0-epa1-amd64.iso"
             }
         },
         {


### PR DESCRIPTION
VyOS published another publicly available pre-release of v1.3.0: v1.3.0-epa1, epa means “early production access”.

---
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
