### PR TITLE
aruba-arubaoscx.gns3a: New Image Versions added

### DIFF
--- a/appliances/aruba-arubaoscx.gns3a
+++ b/appliances/aruba-arubaoscx.gns3a
@@ -96,7 +96,7 @@
         {
             "name": "10.07.0010",
             "images": {
-                "hda_disk_image": "arubaoscx-disk-image-genericx86-p4-20210610000730.ovf"
+                "hda_disk_image": "arubaoscx-disk-image-genericx86-p4-20210610000730.vmdk"
             }
         },
         {

--- a/appliances/aruba-arubaoscx.gns3a
+++ b/appliances/aruba-arubaoscx.gns3a
@@ -31,6 +31,34 @@
     },
     "images": [
         {
+            "filename": "arubaoscx-disk-image-genericx86-p4-20211206170615.vmdk",
+            "version": "10.09.0002",
+            "md5sum": "3c772546482013495e31fc9cb0591b46",
+            "filesize": 555656704,
+            "download_url": "https://asp.arubanetworks.com/"
+        },
+        {
+            "filename": "arubaoscx-disk-image-genericx86-p4-20210812172945.vmdk",
+            "version": "10.08.0001",
+            "md5sum": "762b139432aef1012d8be5afdfcb286e",
+            "filesize": 542237696,
+            "download_url": "https://asp.arubanetworks.com/"
+        },
+        {
+            "filename": "arubaoscx-disk-image-genericx86-p4-20210610000730.vmdk",
+            "version": "10.07.0010",
+            "md5sum": "396dc7ad964b7c517e01bc408e3bf84a",
+            "filesize": 531603968,
+            "download_url": "https://asp.arubanetworks.com/"
+        },
+        {
+            "filename": "arubaoscx-disk-image-genericx86-p4-20210316185909.vmdk",
+            "version": "10.06.0110",
+            "md5sum": "f1ed67d5c7e009e21bfb6a91d9183e8e",
+            "filesize": 381285376,
+            "download_url": "https://asp.arubanetworks.com/"
+        },
+        {
             "filename": "arubaoscx-disk-image-genericx86-p4-20201110192651.vmdk",
             "version": "10.06.0001",
             "md5sum": "f8b45bc52f6bad79b5ff563e0c1ea73b",
@@ -53,6 +81,30 @@
         }
     ],
     "versions": [
+        {
+            "name": "10.09.0002",
+            "images": {
+                "hda_disk_image": "arubaoscx-disk-image-genericx86-p4-20211206170615.vmdk"
+            }
+        },
+        {
+            "name": "10.08.0001",
+            "images": {
+                "hda_disk_image": "arubaoscx-disk-image-genericx86-p4-20210812172945.vmdk"
+            }
+        },
+        {
+            "name": "10.07.0010",
+            "images": {
+                "hda_disk_image": "arubaoscx-disk-image-genericx86-p4-20210610000730.ovf"
+            }
+        },
+        {
+            "name": "10.06.0110",
+            "images": {
+                "hda_disk_image": "arubaoscx-disk-image-genericx86-p4-20210316185909.vmdk"
+            }
+        },
         {
             "name": "10.06.0001",
             "images": {


### PR DESCRIPTION
Aruba CX OVA Version 10.06.0110, 10.07.0010, 10.08.0001 & 10.09.0002 added.

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
