### PR TITLE
vyos - add v1.3.0 and v1.3.0-epa3

### DIFF
--- a/appliances/vyos.gns3a
+++ b/appliances/vyos.gns3a
@@ -27,12 +27,19 @@
     },
     "images": [
         {
-            "filename": "vyos-1.3.0-epa1-amd64.iso",
-            "version": "1.3.0-epa1",
-            "md5sum": "a2aaa5bd3bc5827909d07a18a9de80a7",
+            "filename": "vyos-1.3.0-amd64.iso",
+            "version": "1.3.0",
+            "md5sum": "2019bd9c5efa6194e2761de678d0073f",
+            "filesize": 338690048,
+            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-3-0-generic-iso-image"
+        },
+        {
+            "filename": "vyos-1.3.0-epa3-amd64.iso",
+            "version": "1.3.0-epa3",
+            "md5sum": "1b5de684d8995844e35fa5cec3171811",
             "filesize": 331350016,
             "download_url": "https://vyos.net/get/snapshots/",
-            "direct_download_url": "https://s3.amazonaws.com/s3-us.vyos.io/snapshot/vyos-1.3.0-epa1/generic-iso/vyos-1.3.0-epa1-amd64.iso"
+            "direct_download_url": "https://s3.amazonaws.com/s3-us.vyos.io/snapshot/vyos-1.3.0-epa3/vyos-1.3.0-epa3-amd64.iso"
         },
         {
             "filename": "vyos-1.2.8-amd64.iso",
@@ -67,10 +74,17 @@
     ],
     "versions": [
         {
-            "name": "1.3.0-epa1",
+            "name": "1.3.0",
             "images": {
                 "hda_disk_image": "empty8G.qcow2",
-                "cdrom_image": "vyos-1.3.0-epa1-amd64.iso"
+                "cdrom_image": "vyos-1.3.0-amd64.iso"
+            }
+        },
+        {
+            "name": "1.3.0-epa3",
+            "images": {
+                "hda_disk_image": "empty8G.qcow2",
+                "cdrom_image": "vyos-1.3.0-epa3-amd64.iso"
             }
         },
         {


### PR DESCRIPTION
Added v1.3.0 and replaced the freely available prerelease v1.3.0-epa1 by the latest v1.3.0-epa3.

---

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
