### PR TITLE
Support for Clavister NetShield

### DIFF
--- a/appliances/clavister-netsheild.gns3a
+++ b/appliances/clavister-netsheild.gns3a
@@ -1,0 +1,46 @@
+{
+    "appliance_id": "39c6b8db-8dc3-4b04-8727-7d0b414be7c8",
+    "name": "Clavister NetShield",
+    "category": "firewall",
+    "description": "Clavister NetShield (cOS Stream) Virtual Appliance offers the same functionality as the Clavister NetShield physical NGappliances FWs in a virtual environment.",
+    "vendor_name": "Clavister",
+    "vendor_url": "https://www.clavister.com/",
+    "documentation_url": "https://kb.clavister.com",
+    "product_name": "NetShield",
+    "product_url": "https://www.clavister.com/products/netshield/",
+    "registry_version": 4,
+    "status": "stable",
+    "availability": "free-to-try",
+    "maintainer": "Mattias Nordlund",
+    "maintainer_email": "mattias.nordlund@clavister.com",
+    "usage": "No configuration by default, oen console to set IPs and activate configuration.",
+    "port_name_format": "if{0}",
+    "qemu": {
+        "adapter_type": "virtio-net-pci",
+        "adapters": 4,
+        "ram": 1024,      
+        "hda_disk_interface": "virtio",
+        "arch": "x86_64",
+        "console_type": "telnet",
+        "boot_priority": "c",
+        "kvm": "allow",
+        "options": "-cpu Nehalem"
+    },
+    "images": [
+        {
+            "filename": "clavister-cos-stream-3.80.09.01-virtual-x64-generic.qcow2",
+            "version": "cOS Strean 3.80.09",
+            "md5sum": "b57d8e0f1a3cdd4b2c96ffbc7d7c4f05",
+            "filesize": 134217728,
+            "download_url": "https://my.clavister.com/download/c44639bf-b082-ec11-8308-005056956b6b"
+        }
+    ],
+    "versions": [
+        {
+            "images": {
+                "hda_disk_image": "clavister-cos-stream-3.80.09.01-virtual-x64-generic.qcow2"
+            },
+            "name": "cOS Strean 3.80.09"
+        }
+    ]
+}


### PR DESCRIPTION
Adding Clavister NetShield appliance based in version 3.80

Before submitting a pull request, please check the following.

When creating a new appliance:

It's tested locally, i.e.
[X ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
[ X] GNS3 VM can run it without any tweaks.
[ X] The device is in the right category: router, switch, guest (hosts), firewall
[X ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
[ N/A] When adding a container: it builds on Docker Hub and can be pulled.
[ X] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
[ X] If you forked the repo, running check.py doesn't drop any errors for the new file.
[ N/A] Optional: a symbol has been created for the new appliance.