### PR TITLE
FRR: Update to version 8.1.0

### DIFF
--- a/appliances/frr.gns3a
+++ b/appliances/frr.gns3a
@@ -23,6 +23,14 @@
     },
     "images": [
         {
+            "filename": "frr-8.1.0.qcow2",
+            "version": "8.1.0",
+            "md5sum": "836d6a207f63f99a4039378f2b0c6123",
+            "filesize": 54063616,
+            "download_url": "https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/",
+            "direct_download_url": "http://downloads.sourceforge.net/project/gns-3/Qemu%20Appliances/frr-8.1.0.qcow2"
+        },
+        {
             "filename": "frr-7.5.1.qcow2",
             "version": "7.5.1",
             "md5sum": "4b3ca0932a396b282ba35f102be1ed3b",
@@ -40,6 +48,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "8.1.0",
+            "images": {
+                "hda_disk_image": "frr-8.1.0.qcow2"
+            }
+        },
         {
             "name": "7.5.1",
             "images": {

--- a/packer/alpine-linux/alpine.json
+++ b/packer/alpine-linux/alpine.json
@@ -1,7 +1,7 @@
 {
     "variables": {
-        "iso_url": "http://dl-cdn.alpinelinux.org/alpine/v3.14/releases/x86_64/alpine-virt-3.14.0-x86_64.iso",
-        "iso_checksum": "d568c6c71bb1eee0f65cdf40088daf57032e24f1e3bd2cf8a813f80d2e9e4eab",
+        "iso_url": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-virt-3.15.0-x86_64.iso",
+        "iso_checksum": "e97eaedb3bff39a081d1d7e67629d5c0e8fb39677d6a9dd1eaf2752e39061e02",
         "ui_mode": "cli",
         "vm_name": "alpine_cli.qcow2",
         "file_source": "README.rst",

--- a/packer/alpine-linux/scripts/frr.sh
+++ b/packer/alpine-linux/scripts/frr.sh
@@ -1,5 +1,5 @@
 # add community repository
-sed -i 's/^#\(.*\/v.*\/community\)$/\1/' /etc/apk/repositories
+sed -i 's/^#\s*\(.*\/v.*\/community\)$/\1/' /etc/apk/repositories
 apk update
 
 # install packages

--- a/packer/alpine-linux/scripts/gui.sh
+++ b/packer/alpine-linux/scripts/gui.sh
@@ -1,5 +1,5 @@
 # add community repository
-sed -i 's/^#\(.*\/v.*\/community\)$/\1/' /etc/apk/repositories
+sed -i 's/^#\s*\(.*\/v.*\/community\)$/\1/' /etc/apk/repositories
 apk update
 
 # install packages


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---

Updated the packer files for alpine-linux to use alpine version 3.15.0, then generated an updated FRR image and appliance, now with FRR version 8.1.0.

@grossmj Please download the FRR image from <https://github.com/b-ehlers/gns3-registry/releases/download/frr/frr-8.1.0.qcow2> and upload it to SourceForge <https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/>.