### PR TITLE
Update cisco-asav.gns3a

### DIFF
--- a/appliances/cisco-asav.gns3a
+++ b/appliances/cisco-asav.gns3a
@@ -26,6 +26,13 @@
         "kvm": "require"
     },
     "images": [
+	    {
+            "filename": "asav9-16-2.qcow2",
+            "version": "9.16.2",
+            "md5sum": "1f8db97063a7f738fddc81ac880a906c",
+            "filesize": 262078976,
+            "download_url": "https://software.cisco.com/download/home/286119613/type/280775065/release/9.16.2"
+        },
         {
             "filename": "asav9-15-1.qcow2",
             "version": "9.15.1",
@@ -105,6 +112,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "9.16.2",
+            "images": {
+                "hda_disk_image": "asav9-16-2.qcow2"
+            }
+        },
         {
             "name": "9.15.1",
             "images": {

--- a/appliances/cisco-asav.gns3a
+++ b/appliances/cisco-asav.gns3a
@@ -29,8 +29,8 @@
 	    {
             "filename": "asav9-16-2.qcow2",
             "version": "9.16.2",
-            "md5sum": "1f8db97063a7f738fddc81ac880a906c",
-            "filesize": 262078976,
+            "md5sum": "c3aa2b73b029146ec345bf888dd54eab",
+            "filesize": 264896512,
             "download_url": "https://software.cisco.com/download/home/286119613/type/280775065/release/9.16.2"
         },
         {


### PR DESCRIPTION
Cisco Adaptive Security Virtual Appliance qcow2 package for the Cisco ASAv Virtual Firewall.
asav9-16-2.qcow2

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [x] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [x] GNS3 VM can run it without any tweaks.
  - [x] The device is in the right category: router, switch, guest (hosts), firewall
  - [x] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [x] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [x] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
