### PR TITLE
Add 17.6.1a to cisco-8000v.gns3a

### DIFF
--- a/appliances/cisco-c8000v.gns3a
+++ b/appliances/cisco-c8000v.gns3a
@@ -25,6 +25,13 @@
     },
     "images": [
         {
+            "filename": "c8000v-universalk9_8G_serial.17.06.01a.qcow2",
+            "version": "17.06.01a 8G",
+            "md5sum": "d8b8ae633d953ec1b6d8f18a09a4f4e7",
+            "filesize": 1595277312,
+            "download_url": "https://software.cisco.com/download/home/286327102/type/282046477/release/Bengaluru-17.6.1a"
+        },
+        {
             "filename": "c8000v-universalk9_8G_serial.17.04.01a.qcow2",
             "version": "17.04.01a 8G",
             "md5sum": "5c1dd1d3757ea43b5b02e0af7a010525",
@@ -40,6 +47,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "17.06.01a 8G",
+            "images": {
+                "hda_disk_image": "c8000v-universalk9_8G_serial.17.06.01a.qcow2"
+            }
+        },
         {
             "name": "17.04.01a 8G",
             "images": {


### PR DESCRIPTION
Add 17.6.1a version to Cisco Catalyst 8000v to GNS3 Appliance Registry.

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [x] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [-] GNS3 VM can run it without any tweaks. - Tested on bare metal GNS3 Server installed via PPA
  - [x] The device is in the right category: router, switch, guest (hosts), firewall
  - [x] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [n/a] When adding a container: it builds on Docker Hub and can be pulled.
- [x] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [x] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [n/a] *Optional: a symbol has been created for the new appliance.*
