### PR TITLE
Added Cumulus-VX 5.1.0 to appliance file

### DIFF
--- a/appliances/cumulus-vx.gns3a
+++ b/appliances/cumulus-vx.gns3a
@@ -12,7 +12,7 @@
     "status": "stable",
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
-    "usage": "Default username is cumulus and password is CumulusLinux! in version 4.1 and earlier, and cumulus in version 4.2 and later.",
+    "usage": "Default username/password is cumulus/CumulusLinux! in version 4.1 and earlier, and cumulus/cumulus in version 4.2 and later.",
     "first_port_name": "eth0",
     "port_name_format": "swp{port1}",
     "qemu": {
@@ -25,6 +25,14 @@
         "kvm": "require"
     },
     "images": [
+        {
+            "filename": "cumulus-linux-5.1.0-vx-amd64-qemu.qcow2",
+            "version": "5.1.0",
+            "md5sum": "b46a68bbb57e77fab5c2927367bead13",
+            "filesize": 4174446592,
+            "download_url": "https://www.nvidia.com/en-us/networking/ethernet-switching/cumulus-vx/download/",
+            "direct_download_url": "https://d2cd9e7ca6hntp.cloudfront.net/public/CumulusLinux-5.1.0/cumulus-linux-5.1.0-vx-amd64-qemu.qcow2"
+        },
         {
             "filename": "cumulus-linux-4.3.0-vx-amd64-qemu.qcow2",
             "version": "4.3.0",
@@ -231,6 +239,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "5.1.0",
+            "images": {
+                "hda_disk_image": "cumulus-linux-5.1.0-vx-amd64-qemu.qcow2"
+            }
+        },
         {
             "name": "4.3.0",
             "images": {


### PR DESCRIPTION
Update cumulus-vx.gns3a to include version 5.1.0.


Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance: **N/A**
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
