### PR TITLE
Added ASAv 9.16.2 (CML version) to cisco-asav.gns3a

### DIFF
--- a/appliances/cisco-asav.gns3a
+++ b/appliances/cisco-asav.gns3a
@@ -28,6 +28,13 @@
     "images": [
 	    {
             "filename": "asav9-16-2.qcow2",
+            "version": "9.16.2 CML",
+            "md5sum": "1f8db97063a7f738fddc81ac880a906c",
+            "filesize": 262078976,
+            "download_url": "https://learningnetworkstore.cisco.com/cisco-modeling-labs-personal/cisco-modeling-labs-personal/CML-PERSONAL.html"
+        },
+        {
+            "filename": "asav9-16-2.qcow2",
             "version": "9.16.2",
             "md5sum": "c3aa2b73b029146ec345bf888dd54eab",
             "filesize": 264896512,
@@ -112,6 +119,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "9.16.2 CML",
+            "images": {
+                "hda_disk_image": "asav9-16-2.qcow2"
+            }
+        },
         {
             "name": "9.16.2",
             "images": {


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [-] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
* **Cisco Modeling Labs (Personal) v 2.4.0 has same filename as production ASAv 9.16.2**
- [-] If you forked the repo, running check.py doesn't drop any errors for the updated file.
* **Duplicate filename for cisco-asav-9-16-2.qcow2, referenced above and in #678 **
---
When creating a **new** appliance: N/A
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
