### PR TITLE
Update Fortinet appliances

### DIFF
--- a/appliances/fortianalyzer.gns3a
+++ b/appliances/fortianalyzer.gns3a
@@ -28,6 +28,13 @@
     },
     "images": [
         {
+            "filename": "FAZ_VM64_KVM-v7.2.1-build1215-FORTINET.out.kvm.qcow2",
+            "version": "7.2.1",
+            "md5sum": "c13b6c7678a2fc12ab969fc681ad3af5",
+            "filesize": 340631552,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FAZ_VM64_KVM-v6-build2288-FORTINET.out.kvm.qcow2",
             "version": "6.4.5",
             "md5sum": "e220b48c6e86f8ddc660d578295051a9",
@@ -177,6 +184,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "7.2.1",
+            "images": {
+                "hda_disk_image": "FAZ_VM64_KVM-v7.2.1-build1215-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
         {
             "name": "6.4.5",
             "images": {

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -28,6 +28,13 @@
     },
     "images": [
         {
+            "filename": "FGT_VM64_KVM-v7.2.1.F-build1254-FORTINET.out.kvm.qcow2",
+            "version": "7.2.1",
+            "md5sum": "e382a1ad5c7c16f49a1c0d3f45e3a3b2",
+            "filesize": 86704128,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FGT_VM64_KVM-v6-build1828-FORTINET.out.kvm.qcow2",
             "version": "6.4.5",
             "md5sum": "dc064e16fa65461183544d8ddb5d19d9",
@@ -254,6 +261,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "7.2.1",
+            "images": {
+                "hda_disk_image": "FGT_VM64_KVM-v7.2.1.F-build1254-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
         {
             "name": "6.4.5",
             "images": {

--- a/appliances/fortimail.gns3a
+++ b/appliances/fortimail.gns3a
@@ -28,6 +28,13 @@
     },
     "images": [
         {
+            "filename": "FML_VMKV-64-v721.M-build0364-FORTINET.out.kvm.qcow2",
+            "version": "7.2.1",
+            "md5sum": "b7bf13c2fb013693936b45d89dfab1ac",
+            "filesize": 123535360,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FML_VMKV-64-v60-build0257-FORTINET.out.kvm.qcow2",
             "version": "6.2.1",
             "md5sum": "79449970d26979af79b0ccb7b0cf3880",
@@ -184,6 +191,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "7.2.1",
+            "images": {
+                "hda_disk_image": "FML_VMKV-64-v721.M-build0364-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
         {
             "name": "6.2.1",
             "images": {

--- a/appliances/fortimanager.gns3a
+++ b/appliances/fortimanager.gns3a
@@ -28,6 +28,13 @@
     },
     "images": [
         {
+            "filename": "FMG_VM64_KVM-v7.2.1-build1215-FORTINET.out.kvm.qcow2",
+            "version": "7.2.1",
+            "md5sum": "1a3eeff1204fa8f4243773f7521e12b5",
+            "filesize": 242814976,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FMG_VM64_KVM-v6-build2288-FORTINET.out.kvm.qcow2",
             "version": "6.4.5",
             "md5sum": "bd2791984b03f55a6825297e83c6576a",
@@ -177,6 +184,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "7.2.1",
+            "images": {
+                "hda_disk_image": "FMG_VM64_KVM-v7.2.1-build1215-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
         {
             "name": "6.4.5",
             "images": {

--- a/appliances/fortiproxy.gns3a
+++ b/appliances/fortiproxy.gns3a
@@ -28,6 +28,13 @@
     },
     "images": [
         {
+            "filename": "FPX_KVM-v700.M-build0102-FORTINET.out.kvm.qcow2",
+            "version": "7.0.6",
+            "md5sum": "ad0a4612580b5a2754cc4e0121a9cf22",
+            "filesize": 146800640,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FPX_KVM-v100-build0162-FORTINET.out.kvm.qcow2",
             "version": "1.1.2",
             "md5sum": "00db4c04fcc4ac0d7c389a86c71d20a5",
@@ -51,6 +58,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "7.0.6",
+            "images": {
+                "hda_disk_image": "FPX_KVM-v700.M-build0102-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
         {
             "name": "1.1.2",
             "images": {

--- a/appliances/fortisandbox.gns3a
+++ b/appliances/fortisandbox.gns3a
@@ -29,6 +29,13 @@
     },
     "images": [
         {
+            "filename": "FSA_KVM-v400-build0231-FORTINET.out.kvm.qcow2",
+            "version": "4.2.2",
+            "md5sum": "02b7f49e3c04861601a7af26452eed66",
+            "filesize": 156172304,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FSA_KVM-v300-build0124-FORTINET.out.kvm.qcow2",
             "version": "3.1.2",
             "md5sum": "fc2b9a00d20063a6fa4103360d89a2d4",
@@ -114,6 +121,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "4.2.2",
+            "images": {
+                "hda_disk_image": "FSA_KVM-v400-build0231-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "FSA-datadrive.qcow2"
+            }
+        },
         {
             "name": "3.1.2",
             "images": {

--- a/appliances/fortiweb.gns3a
+++ b/appliances/fortiweb.gns3a
@@ -28,6 +28,13 @@
     },
     "images": [
         {
+            "filename": "FWB_KVM-v700-build0097-FORTINET.out.kvm.qcow2",
+            "version": "7.0.1",
+            "md5sum": "a197e9db03ffaf7feb520c8f77f940f7",
+            "filesize": 257622528,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FWB_KVM-v600-build0727-FORTINET.out.kvm.qcow2",
             "version": "6.2.1",
             "md5sum": "05523a6db26030a8fc3d84e53902d162",
@@ -121,6 +128,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "7.0.1",
+            "images": {
+                "hda_disk_image": "FWB_KVM-v700-build0097-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
         {
             "name": "6.2.1",
             "images": {


### PR DESCRIPTION
Update of following Fortinet appliances:
-fortiweb -> 7.0.1 added
-fortisandbox -> 4.2.2 added
-fortiproxy -> 7.0.6 added
-fortimanager -> 7.2.1 added
-fortimail -> 7.2.1 added
-fortigate -> 7.2.1 added
-fortianalyzer -> 7.2.1 added
Images were tested locally, each appliance is reachable via ping and web interface.



Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ Yes ] The new version is on top.
- [ Yes ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ Yes ] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
