### PR TITLE
Fixed many careless issues on Alpine Linux Virt

### DIFF
--- a/appliances/alpine-linux-virt.gns3a
+++ b/appliances/alpine-linux-virt.gns3a
@@ -7,7 +7,7 @@
     "vendor_url": "http://alpinelinux.org",
     "documentation_url": "http://wiki.alpinelinux.org",
     "product_name": "Alpine Linux Virt",
-    "registry_version": 3,
+    "registry_version": 4,
     "status": "stable",
     "availability": "free",
     "maintainer": "Adnan RIHAN",
@@ -28,8 +28,8 @@
         {
             "filename": "alpine-virt-3.16.img",
             "version": "3.16",
-            "md5sum": "d5d11ad03060026ce20dc1bfa2f3c35b",
-            "filesize": 188416,
+            "md5sum": "1d7d2790221144667d7e550cfe30972a",
+            "filesize": 96468992,
             "download_url": "https://drive.google.com/file/d/1xWGEMez7R9RVq2-c3qnypkt0t5Sxq2KD/view?usp=sharing",
             "direct_download_url": "https://drive.google.com/uc?export=download&id=1xWGEMez7R9RVq2-c3qnypkt0t5Sxq2KD"
         }


### PR DESCRIPTION
- `registry_version`
- autologin on ttyS0 instead of tty1
- filesize

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
- It's tested locally, i.e.
  - [X] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [X] GNS3 VM can run it without any tweaks.
  - [X] The device is in the right category: router, switch, guest (hosts), firewall
  - [X] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [X] If you forked the repo, running check.py doesn't drop any errors for the new file.
