### PR TITLE
Create basic Debian packer template

### DIFF
--- a/packer/debian/README.md
+++ b/packer/debian/README.md
@@ -1,0 +1,15 @@
+# Packer for Debian based GNS3 appliances
+
+## Packer Version Dependency
+
+Packer versions 1.6.0 or later do not accept templates
+that use the `iso_checksum_type` attribute.
+To use these newer versions, you must delete the line
+containing `iso_checksum_type` from debian.json.
+
+
+## Debian CLI installation
+
+```
+packer build debian.json
+```

--- a/packer/debian/debian-cloud-init-data.iso
+++ b/packer/debian/debian-cloud-init-data.iso
@@ -1,0 +1,1 @@
+../../cloud-init/Debian/debian-cloud-init-data.iso

--- a/packer/debian/debian.json
+++ b/packer/debian/debian.json
@@ -1,0 +1,43 @@
+{
+    "variables": {
+        "iso_url": "https://cloud.debian.org/images/cloud/bullseye/20220911-1135/debian-11-genericcloud-amd64-20220911-1135.qcow2",
+        "iso_checksum": "2808ca1fa62c6a0a5fa92b49b6bc43755fb30a7eb5d4f753f372017474fbd54c",
+        "disk_size": "2G",
+        "vm_name": "debian.qcow2",
+        "setup_script": "debian.sh"
+    },
+    "provisioners": [
+        {
+            "type": "shell",
+            "script": "scripts/remove_cloud-init_network.sh"
+        },
+        {
+            "type": "shell",
+            "script": "scripts/{{user `setup_script`}}"
+        },
+        {
+            "type": "shell",
+            "script": "scripts/post_setup.sh"
+        }
+    ],
+    "builders": [
+        {
+            "type": "qemu",
+            "disk_image": true,
+            "disk_size": "{{user `disk_size`}}",
+            "iso_url": "{{user `iso_url`}}",
+            "iso_checksum": "{{user `iso_checksum`}}",
+            "iso_checksum_type": "sha256",
+            "disk_interface": "virtio-scsi",
+            "disk_compression": true,
+            "headless": true,
+            "net_device": "virtio-net-pci",
+            "qemuargs": [ [ "-cdrom", "debian-cloud-init-data.iso" ] ],
+            "shutdown_command": "sudo poweroff",
+            "ssh_username": "debian",
+            "ssh_password": "debian",
+            "ssh_wait_timeout": "30s",
+            "vm_name": "{{user `vm_name`}}"
+        }
+    ]
+}

--- a/packer/debian/scripts/debian.sh
+++ b/packer/debian/scripts/debian.sh
@@ -1,0 +1,2 @@
+# create GNS3 user
+printf 'gns3\ngns3\n' | sudo adduser --gecos 'GNS3' gns3

--- a/packer/debian/scripts/post_setup.sh
+++ b/packer/debian/scripts/post_setup.sh
@@ -1,0 +1,9 @@
+sudo -- sh -c "
+# clear repository
+apt-get clean
+
+# clear unused space
+echo 'Clearing unused space...'
+dd if=/dev/zero bs=1M of=/zero >/dev/null 2>&1; rm -f /zero
+sync
+"

--- a/packer/debian/scripts/remove_cloud-init_network.sh
+++ b/packer/debian/scripts/remove_cloud-init_network.sh
@@ -1,0 +1,26 @@
+# replace cloud-init network configuration
+sudo -- sh -c "
+cat > /etc/network/interfaces <<'EOF'
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+source /etc/network/interfaces.d/*
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+# DHCP config for ens4
+#auto ens4
+#iface ens4 inet dhcp
+
+# Static config for ens4
+#auto ens4
+#iface ens4 inet static
+#	address 192.168.1.100
+#	netmask 255.255.255.0
+#	gateway 192.168.1.1
+#	dns-nameservers 192.168.1.1
+EOF
+rm -f /etc/network/interfaces.d/50-cloud-init
+"


### PR DESCRIPTION
This doesn't add/change an appliance, it only creates a basic Debian packer template. It uses the official Debian cloud image as a base image.

User debian (password debian) is the root user replacement, it is allowed to run passwordless sudo.
User gns3 (password gns3) is an unprivileged user.

Currently it doesn't add much to the cloud image, so it doesn't make much sense to create an appliance from this. The idea is, to use it as a base for other appliances. 

Sorry, I don't have time to help on issue https://github.com/GNS3/gns3-registry/issues/697, but maybe this Debian packer script helps.