### PR TITLE
packer/alpine-linux update to 3.16

### DIFF
--- a/packer/alpine-linux/README.rst
+++ b/packer/alpine-linux/README.rst
@@ -6,15 +6,6 @@ For building an Alpine appliance.
 https://alpinelinux.org/
 
 
-Packer Version Dependency
-*************************
-
-Packer versions 1.6.0 or later do not accept templates
-that use the ``iso_checksum_type`` attribute.
-To use these newer versions, you must delete the line
-containing ``iso_checksum_type`` from alpine.json.
-
-
 Alpine CLI installation
 ***********************
 

--- a/packer/alpine-linux/alpine.json
+++ b/packer/alpine-linux/alpine.json
@@ -13,7 +13,6 @@
             "type": "qemu",
             "iso_url": "{{user `iso_url`}}",
             "iso_checksum": "{{user `iso_checksum`}}",
-            "iso_checksum_type": "sha256",
             "shutdown_command": "poweroff",
             "headless": true,
             "ssh_username": "root",

--- a/packer/alpine-linux/alpine.json
+++ b/packer/alpine-linux/alpine.json
@@ -1,7 +1,7 @@
 {
     "variables": {
-        "iso_url": "https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-virt-3.15.0-x86_64.iso",
-        "iso_checksum": "e97eaedb3bff39a081d1d7e67629d5c0e8fb39677d6a9dd1eaf2752e39061e02",
+        "iso_url": "https://dl-cdn.alpinelinux.org/alpine/v3.16/releases/x86_64/alpine-virt-3.16.3-x86_64.iso",
+        "iso_checksum": "file:https://dl-cdn.alpinelinux.org/alpine/v3.16/releases/x86_64/alpine-virt-3.16.3-x86_64.iso.sha256",
         "ui_mode": "cli",
         "vm_name": "alpine_cli.qcow2",
         "file_source": "README.rst",

--- a/packer/alpine-linux/scripts/cli.sh
+++ b/packer/alpine-linux/scripts/cli.sh
@@ -1,5 +1,17 @@
-# use serial console
-sed -i 's/\(APPEND .*\)/\1 console=ttyS0/' /boot/extlinux.conf
+#!/bin/sh
+
+set -e
+
+# use serial console and remove quiet
+sed -i 's/\(APPEND .*\)/\1 console=tty0 console=ttyS0,115200 earlyprintk=ttyS0,115200 consoleblank=0/' /boot/extlinux.conf
+sed -i '/\(APPEND .*\)/s/[[:space:]]*quiet[[:space:]]*/ /g' /boot/extlinux.conf
+
 
 # autologin on serial console
-sed -i 's/^ttyS0.*/ttyS0::respawn:\/bin\/login -f root/' /etc/inittab
+cat <<'EOF' | tee /usr/local/bin/rootlogin
+#!/bin/sh
+exec /bin/login -f root
+EOF
+chmod +x /usr/local/bin/rootlogin
+#/sbin/getty -L ttyS0 115200 vt100
+sed -i 's/^ttyS0.*/ttyS0::respawn:\/sbin\/getty -n -l \/usr\/local\/bin\/rootlogin -L ttyS0 115200 vt100/' /etc/inittab

--- a/packer/alpine-linux/scripts/frr.sh
+++ b/packer/alpine-linux/scripts/frr.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # add community repository
 sed -i 's/^#\s*\(.*\/v.*\/community\)$/\1/' /etc/apk/repositories
 apk update

--- a/packer/alpine-linux/scripts/frr.sh
+++ b/packer/alpine-linux/scripts/frr.sh
@@ -44,8 +44,8 @@ sed -i -E '/zebra|bgp|ospf|rip|isis|pim|ldp|eigrp|static|bfd/ s/= *no/=yes/' /et
 echo "service integrated-vtysh-config" > /etc/frr/vtysh.conf
 chown frr:frr /etc/frr/vtysh.conf
 
-# reset terminal modes
-sed -i "$(printf '1i\e[?5l\e[?7h\e[?8h')" /etc/motd
+# Remove default Alpine MOTD
+truncate -s 0 /etc/motd
 
 # run vtysh in .profile
 cat > /root/.profile << 'EOF'

--- a/packer/alpine-linux/scripts/install.sh
+++ b/packer/alpine-linux/scripts/install.sh
@@ -1,28 +1,36 @@
 #!/bin/sh
+# shellcheck disable=SC2034
 
 set -e
 
-export HOSTNAMEOPTS="-n alpine"
-export KEYMAPOPTS="us us"
-export INTERFACESOPTS="auto lo
+# Export most answers for setup-alpine
+set -a
+KEYMAPOPTS="us us"
+HOSTNAMEOPTS="-n alpine"
+INTERFACESOPTS="auto lo
 iface lo inet loopback
 
 auto eth0
 iface eth0 inet dhcp
+    hostname alpine
 "
-export TIMEZONEOPTS="-z UTC"
-export PROXYOPTS="none"
-export APKREPOSOPTS="-1"
-export SSHDOPTS="-c openssh"
-export NTPOPTS="-c none"
-export BOOT_SIZE=50
-export SWAP_SIZE=0
+TIMEZONEOPTS="-z UTC"
+PROXYOPTS="none"
+APKREPOSOPTS="-1"
+SSHDOPTS="-c openssh"
+NTPOPTS="-c none"
+DISKOPTS="-m sys /dev/sda"
+BOOT_SIZE=50
+SWAP_SIZE=0
+set +a
 
-# Answer to password question twice and yes to format drive
+# - Answer to password question twice
+# - Do not create unprivileged user
+# - Select disk
+# - Confirm formatting disk
 setup-alpine <<EOF
 root
 root
-sda
-sys
+no
 y
 EOF

--- a/packer/alpine-linux/scripts/post_setup.sh
+++ b/packer/alpine-linux/scripts/post_setup.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # restore default sshd configuration
 mv /etc/ssh/sshd_config.orig /etc/ssh/sshd_config
 

--- a/packer/alpine-linux/scripts/post_setup.sh
+++ b/packer/alpine-linux/scripts/post_setup.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+set -e
+
 # restore default sshd configuration
 mv /etc/ssh/sshd_config.orig /etc/ssh/sshd_config
 
@@ -9,4 +12,4 @@ rm -rf /var/cache/apk/*
 rm -rf /tmp/uploads
 
 # Write 0
-dd if=/dev/zero bs=1M of=/zero ; rm -f /zero
+(dd if=/dev/zero bs=1M of=/zero ; rm -f /zero) || true

--- a/packer/alpine-linux/scripts/setup.sh
+++ b/packer/alpine-linux/scripts/setup.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+set -e
+
 # install additional packages
 apk add nano busybox-extras
 

--- a/packer/alpine-linux/scripts/setup.sh
+++ b/packer/alpine-linux/scripts/setup.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # install additional packages
 apk add nano busybox-extras
 


### PR DESCRIPTION
This updates the packer/alpine-linux toolchain for 3.16, plus some minor improvements.

The work is done to allow to build more up-to date (frr 8.2.2) versions of the [FRRouting marketplace appliance](https://www.gns3.com/marketplace/appliances/frr) (`appliances/frr.gns3a`) which as far as I can see seem to be built from this toolchain.

I tested the manual import of a locally-built image with the same settings of the `frr.gns3a` appliance, and the image booted without issues. I only performed basic configuration tests on it.

I did not test any of the other images buildable by the toolchain. I did not see clear traces of them in the marketplace, so I guessed they were probably retired, or used only as intermediate products or local images.

In a not entirely related issue (#697) I was suggested to provide a reference image file to ease the team's work, and encouraged to provide an update `.gns3a` template. Unfortunately I do not have access to a long term cloud storage solution suitable for sharing, I could provide only ephemeral links. As such, it seems pointless to provide a `.gns3a` update if I cannot provide proper links for the images. I would appreciate your help in:

* Building an image following the documented procedure: `packer build -var-file frr.json alpine.json`
* Uploading the image to a proper hosting solution
* Updating `appliances/frr.gns3a` to include the new image/version 8.2.2

Sorry for the additional work, I hope the contribution is welcome anyway.