### PR TITLE
vyos - add v1.2.9

### DIFF
--- a/appliances/vyos.gns3a
+++ b/appliances/vyos.gns3a
@@ -55,6 +55,13 @@
             "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-3-0-generic-iso-image"
         },
         {
+            "filename": "vyos-1.2.9-amd64.iso",
+            "version": "1.2.9",
+            "md5sum": "586be23b6256173e174c82d8f1f699a1",
+            "filesize": 430964736,
+            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-generic-iso-image"
+        },
+        {
             "filename": "vyos-1.2.8-amd64.iso",
             "version": "1.2.8",
             "md5sum": "0ad879db903efdbf1c39dc945e165931",
@@ -112,6 +119,13 @@
             "images": {
                 "hda_disk_image": "empty8G.qcow2",
                 "cdrom_image": "vyos-1.3.0-amd64.iso"
+            }
+        },
+        {
+            "name": "1.2.9",
+            "images": {
+                "hda_disk_image": "empty8G.qcow2",
+                "cdrom_image": "vyos-1.2.9-amd64.iso"
             }
         },
         {


### PR DESCRIPTION
Added vyos v1.2.9, a maintenance release of the 1.2 branch.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
