### PR TITLE
Update ntopng.gns3a

### DIFF
--- a/appliances/ntopng.gns3a
+++ b/appliances/ntopng.gns3a
@@ -14,7 +14,7 @@
     "usage": "In the web interface login as admin/admin\n\nPersistent configuration:\n- Add \"/var/lib/redis\" as an additional persistent directory.\n- Use \"redis-cli save\" in an auxiliary console to save the configuration.",
     "docker": {
         "adapters": 1,
-        "image": "ntop/ntopng:stable",
+        "image": "ntop/ntopng:latest",
         "start_command": "--dns-mode 2 --interface eth0",
         "console_type": "http",
         "console_http_port": 3000,


### PR DESCRIPTION
Hi, the appliance doesn't work as it is because GNS3 tries to pull ntopng with 'stable' tag, but only tag available now is 'latest' on hub.docker.com.