### PR TITLE
Debian packer template: Improvements

### DIFF
--- a/packer/debian/debian.json
+++ b/packer/debian/debian.json
@@ -9,15 +9,18 @@
     "provisioners": [
         {
             "type": "shell",
-            "script": "scripts/remove_cloud-init_network.sh"
+            "script": "scripts/remove_cloud-init_network.sh",
+            "execute_command" : "sudo env {{ .Vars }} {{ .Path }}"
         },
         {
             "type": "shell",
-            "script": "scripts/{{user `setup_script`}}"
+            "script": "scripts/{{user `setup_script`}}",
+            "execute_command" : "sudo env {{ .Vars }} {{ .Path }}"
         },
         {
             "type": "shell",
-            "script": "scripts/post_setup.sh"
+            "script": "scripts/post_setup.sh",
+            "execute_command" : "sudo env {{ .Vars }} {{ .Path }}"
         }
     ],
     "builders": [
@@ -33,7 +36,7 @@
             "headless": true,
             "net_device": "virtio-net-pci",
             "qemuargs": [ [ "-cdrom", "debian-cloud-init-data.iso" ] ],
-            "shutdown_command": "sudo poweroff",
+            "shutdown_command": "sudo shutdown -P now",
             "ssh_username": "debian",
             "ssh_password": "debian",
             "ssh_wait_timeout": "30s",

--- a/packer/debian/scripts/debian.sh
+++ b/packer/debian/scripts/debian.sh
@@ -1,2 +1,5 @@
+#!/bin/sh
+set -ex
+
 # create GNS3 user
-printf 'gns3\ngns3\n' | sudo adduser --gecos 'GNS3' gns3
+printf 'gns3\ngns3\n' | adduser --gecos 'GNS3' gns3

--- a/packer/debian/scripts/post_setup.sh
+++ b/packer/debian/scripts/post_setup.sh
@@ -1,9 +1,10 @@
-sudo -- sh -c "
+#!/bin/sh
+set -ex
+
 # clear repository
 apt-get clean
 
 # clear unused space
 echo 'Clearing unused space...'
-dd if=/dev/zero bs=1M of=/zero >/dev/null 2>&1; rm -f /zero
+dd if=/dev/zero bs=1M of=/zero >/dev/null 2>&1 || true; rm -f /zero
 sync
-"

--- a/packer/debian/scripts/remove_cloud-init_network.sh
+++ b/packer/debian/scripts/remove_cloud-init_network.sh
@@ -1,5 +1,7 @@
+#!/bin/sh
+set -ex
+
 # replace cloud-init network configuration
-sudo -- sh -c "
 cat > /etc/network/interfaces <<'EOF'
 # This file describes the network interfaces available on your system
 # and how to activate them. For more information, see interfaces(5).
@@ -23,4 +25,3 @@ iface lo inet loopback
 #	dns-nameservers 192.168.1.1
 EOF
 rm -f /etc/network/interfaces.d/50-cloud-init
-"


### PR DESCRIPTION
Added some improvements to the Debian packer template, no appliance is affected. These improvements were inspired by  <https://github.com/giangi/frr-gns3/tree/master/debian-cloud>, many thanks for that.

- run scripts as root, no sudo needed within scripts
- add shebang to scripts
- add "set -ex" to abort scripts on error and to display commands
