### PR TITLE
Debian: Update to version 11.6

### DIFF
--- a/appliances/debian.gns3a
+++ b/appliances/debian.gns3a
@@ -24,12 +24,12 @@
     },
     "images": [
         {
-            "filename": "debian-11-genericcloud-amd64-20220911-1135.qcow2",
-            "version": "11.5",
-            "md5sum": "06e481ddd23682af4326226661c13d8f",
-            "filesize": 254672896,
+            "filename": "debian-11-genericcloud-amd64-20221219-1234.qcow2",
+            "version": "11.6",
+            "md5sum": "bd6ddbccc89e40deb7716b812958238d",
+            "filesize": 258801664,
             "download_url": "https://cloud.debian.org/images/cloud/bullseye/",
-            "direct_download_url": "https://cloud.debian.org/images/cloud/bullseye/20220911-1135/debian-11-genericcloud-amd64-20220911-1135.qcow2"
+            "direct_download_url": "https://cloud.debian.org/images/cloud/bullseye/20221219-1234/debian-11-genericcloud-amd64-20221219-1234.qcow2"
         },
         {
             "filename": "debian-10-genericcloud-amd64-20220911-1135.qcow2",
@@ -49,9 +49,9 @@
     ],
     "versions": [
         {
-            "name": "11.5",
+            "name": "11.6",
             "images": {
-                "hda_disk_image": "debian-11-genericcloud-amd64-20220911-1135.qcow2",
+                "hda_disk_image": "debian-11-genericcloud-amd64-20221219-1234.qcow2",
                 "cdrom_image": "debian-cloud-init-data.iso"
             }
         },

--- a/packer/debian/debian.json
+++ b/packer/debian/debian.json
@@ -1,7 +1,7 @@
 {
     "variables": {
-        "iso_url": "https://cloud.debian.org/images/cloud/bullseye/20220911-1135/debian-11-genericcloud-amd64-20220911-1135.qcow2",
-        "iso_checksum": "2808ca1fa62c6a0a5fa92b49b6bc43755fb30a7eb5d4f753f372017474fbd54c",
+        "iso_url": "https://cloud.debian.org/images/cloud/bullseye/20221219-1234/debian-11-genericcloud-amd64-20221219-1234.qcow2",
+        "iso_checksum": "ba0237232247948abf7341a495dec009702809aa7782355a1b35c112e75cee81",
         "disk_size": "2G",
         "vm_name": "debian.qcow2",
         "setup_script": "debian.sh"


### PR DESCRIPTION
Debian: Upgrade to version 11.6

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
