### PR TITLE
Added version 7.0.5 to FortiWeb

### DIFF
--- a/appliances/fortiweb.gns3a
+++ b/appliances/fortiweb.gns3a
@@ -28,6 +28,13 @@
     },
     "images": [
         {
+            "filename": "FWB_KVM-v700-build0129-FORTINET.out.kvm.qcow2",
+            "version": "7.0.5",
+            "md5sum": "dc14114c68cf42df322e5b89bffd9bf7",
+            "filesize": 258146816,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FWB_KVM-v700-build0097-FORTINET.out.kvm.qcow2",
             "version": "7.0.1",
             "md5sum": "a197e9db03ffaf7feb520c8f77f940f7",
@@ -128,6 +135,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "7.0.5",
+            "images": {
+                "hda_disk_image": "FWB_KVM-v700-build0129-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
         {
             "name": "7.0.1",
             "images": {


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file. (other than known warning for the two ASAv versions)
---
When creating a **new** appliance: **N/A**
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
