### PR TITLE
Add 1.2.0 image to Ostinato appliance

### DIFF
--- a/appliances/ostinato.gns3a
+++ b/appliances/ostinato.gns3a
@@ -30,6 +30,13 @@
     },
     "images": [
         {
+            "filename": "ostinatostd-1.2.0-1.qcow2",
+            "version": "1.2.0",
+            "md5sum": "682680fe75f88975992c0a1a5c973149",
+            "filesize": 173801472,
+            "download_url": "https://ostinato.org/pricing/gns3"
+        },
+        {
             "filename": "ostinatostd-1.1-1.qcow2",
             "version": "1.1",
             "md5sum": "aa027e83cefea1c38d0102eb2f28956e",
@@ -38,6 +45,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "1.2.0",
+            "images": {
+                "hda_disk_image": "ostinatostd-1.2.0-1.qcow2"
+            }
+        },
         {
             "name": "1.1",
             "images": {


### PR DESCRIPTION
Verified:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.

