### PR TITLE
Multiple FortiNet appliance version/usage updates, fixed C7200 .gns3a file

### DIFF
--- a/appliances/cisco-7200.gns3a
+++ b/appliances/cisco-7200.gns3a
@@ -26,13 +26,13 @@
             "version": "153-3.XB12",
             "md5sum": "3d234a3793331c972776354531f87221",
             "filesize": 131471340
-        }
+        },
         {
             "filename": "c7200-advipservicesk9-mz.152-4.S5.image",
             "version": "152-4.S5",
             "md5sum": "cbbbea66a253f1dac0fcf81274dc778d",
             "filesize": 87756936
-        }
+        },
         {
             "filename": "c7200-adventerprisek9-mz.124-24.T5.image",
             "version": "124-24.T5",
@@ -47,14 +47,14 @@
             "images": {
                 "image": "c7200-adventerprisek9-mz.153-3.XB12.image"
             }
-        }
+        },
         {
             "name": "152-4.S5",
             "idlepc": "0x62cc930c",
             "images": {
                 "image": "c7200-advipservicesk9-mz.152-4.S5.image"
             }
-        }
+        },
         {
             "name": "124-24.T5",
             "idlepc": "0x606df838",

--- a/appliances/fortiadc.gns3a
+++ b/appliances/fortiadc.gns3a
@@ -35,10 +35,31 @@
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
+            "filename": "FAD_KVM-V7.2.0-build0210-FORTINET.out.kvm-boot.qcow2",
+            "version": "7.2.0",
+            "md5sum": "e01f14443b0434adc803c482bb92e3a2",
+            "filesize": 145817600,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FAD_KVM-V7.1.1-build0117-FORTINET.out.kvm-boot.qcow2",
+            "version": "7.1.1",
+            "md5sum": "3ab1a886e4961ded804588de6f3b2e27",
+            "filesize": 134807552,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FAD_KVM-v700-build0111-FORTINET.out.kvm-boot.qcow2",
             "version": "7.1.0",
             "md5sum": "5977fe2e031dfa5759b7b2c9958eeb09",
             "filesize": 134676480,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FAD_KVM-V7.0.5-build0053-FORTINET.out.kvm-boot.qcow2",
+            "version": "7.0.5",
+            "md5sum": "3285114b8f317a367b7bcf79631a42f9",
+            "filesize": 127860736,
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
@@ -226,9 +247,30 @@
     ],
     "versions": [
         {
+            "name": "7.2.0",
+            "images": {
+                "hda_disk_image": "FAD_KVM-V7.2.0-build0210-FORTINET.out.kvm-boot.qcow2",
+                "hdb_disk_image": "FAD_KVM-FORTINET.out.kvm-data.qcow2"
+            }
+        },
+        {
+            "name": "7.1.1",
+            "images": {
+                "hda_disk_image": "FAD_KVM-V7.1.1-build0117-FORTINET.out.kvm-boot.qcow2",
+                "hdb_disk_image": "FAD_KVM-FORTINET.out.kvm-data.qcow2"
+            }
+        },
+        {
             "name": "7.1.0",
             "images": {
                 "hda_disk_image": "FAD_KVM-v700-build0111-FORTINET.out.kvm-boot.qcow2",
+                "hdb_disk_image": "FAD_KVM-FORTINET.out.kvm-data.qcow2"
+            }
+        },
+        {
+            "name": "7.0.5",
+            "images": {
+                "hda_disk_image": "FAD_KVM-V7.0.5-build0053-FORTINET.out.kvm-boot.qcow2",
                 "hdb_disk_image": "FAD_KVM-FORTINET.out.kvm-data.qcow2"
             }
         },

--- a/appliances/fortianalyzer.gns3a
+++ b/appliances/fortianalyzer.gns3a
@@ -12,7 +12,7 @@
     "status": "stable",
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
-    "usage": "Default username is admin, no password is set.",
+    "usage": "Default username is admin, no password is set.\n\n- Versions 7.0 and higher require:\n--RAM: 8192 MB\n--CPU:4",
     "symbol": "fortinet.svg",
     "port_name_format": "Port{port1}",
     "qemu": {

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -12,7 +12,7 @@
     "status": "stable",
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
-    "usage": "Default username is admin, no password is set.",
+    "usage": "Default username is admin, no password is set.\n\n- FortiGate version 7.0.0 and above require 2GB RAM.\n\n- FortiGate versions higher than 7.2.0 trial license is VERY restrictive, not recommended for use.",
     "symbol": "fortinet.svg",
     "port_name_format": "Port{port1}",
     "qemu": {

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -63,6 +63,13 @@
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
+            "filename": "FGT_VM64_KVM-v6.4.12.M-build2060-FORTINET.out.kvm.qcow2",
+            "version": "6.4.12",
+            "md5sum": "df2569f9fa3e40b65fa0db741cf6e01e",
+            "filesize": 69861376,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FGT_VM64_KVM-v6.M-build2030-FORTINET.out.kvm.qcow2",
             "version": "6.4.11",
             "md5sum": "bcd7491ddfa31fec4f618b73792456e4",
@@ -328,6 +335,13 @@
             "name": "7.0.9",
             "images": {
                 "hda_disk_image": "FGT_VM64_KVM-v7.0.9.M-build0444-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "6.4.12",
+            "images": {
+                "hda_disk_image": "FGT_VM64_KVM-v6.4.12.M-build2060-FORTINET.out.kvm.qcow2",
                 "hdb_disk_image": "empty30G.qcow2"
             }
         },

--- a/appliances/fortimail.gns3a
+++ b/appliances/fortimail.gns3a
@@ -28,10 +28,31 @@
     },
     "images": [
         {
+            "filename": "FML_VMKV-64-v722.M-build0380-FORTINET.out.kvm.qcow2",
+            "version": "7.2.2",
+            "md5sum": "ec7c32c90f4cfba32a744ea74adc596b",
+            "filesize": 124387328,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FML_VMKV-64-v721.M-build0364-FORTINET.out.kvm.qcow2",
             "version": "7.2.1",
             "md5sum": "b7bf13c2fb013693936b45d89dfab1ac",
             "filesize": 123535360,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FML_VMKV-64-v705-build0208-FORTINET.out.kvm.qcow2",
+            "version": "7.0.5",
+            "md5sum": "62e561465ff8134efdea6f66ba9ccf20",
+            "filesize": 118226944,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FML_VMKV-64-v647-build0467-FORTINET.out.kvm.qcow2",
+            "version": "6.4.7",
+            "md5sum": "11fab90b39d88446a711bbd01802aca1",
+            "filesize": 112066560,
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
@@ -192,9 +213,30 @@
     ],
     "versions": [
         {
+            "name": "7.2.2",
+            "images": {
+                "hda_disk_image": "FML_VMKV-64-v722.M-build0380-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
             "name": "7.2.1",
             "images": {
                 "hda_disk_image": "FML_VMKV-64-v721.M-build0364-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "7.0.5",
+            "images": {
+                "hda_disk_image": "FML_VMKV-64-v705-build0208-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "6.4.7",
+            "images": {
+                "hda_disk_image": "FML_VMKV-64-v647-build0467-FORTINET.out.kvm.qcow2",
                 "hdb_disk_image": "empty30G.qcow2"
             }
         },

--- a/appliances/fortimanager.gns3a
+++ b/appliances/fortimanager.gns3a
@@ -12,7 +12,7 @@
     "status": "stable",
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
-    "usage": "Default username is admin, no password is set.",
+    "usage": "Default username is admin, no password is set.\n\n- Versions 7.0 and higher require:\n--RAM: 8192 MB\n--CPU:4",
     "symbol": "fortinet.svg",
     "port_name_format": "Port{port1}",
     "qemu": {

--- a/appliances/fortiweb.gns3a
+++ b/appliances/fortiweb.gns3a
@@ -28,6 +28,20 @@
     },
     "images": [
         {
+            "filename": "FWB_KVM-v7.2.1-build0330-FORTINET.out.kvm.boot.qcow2",
+            "version": "7.2.1",
+            "md5sum": "5806524ca31401c313e0e86e992b6659",
+            "filesize": 260506112,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FWB_KVM-v7.0.6-build0140-FORTINET.out.kvm.boot.qcow2",
+            "version": "7.0.6",
+            "md5sum": "1327019e891678a0f2fb9602086d998d",
+            "filesize": 258408960,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FWB_KVM-v700-build0129-FORTINET.out.kvm.qcow2",
             "version": "7.0.5",
             "md5sum": "dc14114c68cf42df322e5b89bffd9bf7",
@@ -135,6 +149,20 @@
         }
     ],
     "versions": [
+        {
+            "name": "7.2.1",
+            "images": {
+                "hda_disk_image": "FWB_KVM-v7.2.1-build0330-FORTINET.out.kvm.boot.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "7.0.6",
+            "images": {
+                "hda_disk_image": "FWB_KVM-v7.0.6-build0140-FORTINET.out.kvm.boot.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
         {
             "name": "7.0.5",
             "images": {


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x]  The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
