### PR TITLE
vyos - add KVM images, v1.2.9-S1 and v1.2.9

### DIFF
--- a/appliances/vyos.gns3a
+++ b/appliances/vyos.gns3a
@@ -12,7 +12,7 @@
     "status": "stable",
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
-    "usage": "Default username/password is vyos/vyos.\n\nAt first boot the router will start from the cdrom. Login and then type \"install image\" and follow the instructions.",
+    "usage": "Default username/password is vyos/vyos.\n\nThe -KVM versions are ready to use, no installation is required.\nThe other images will start the router from the CDROM on initial boot. Login and then type \"install image\" and follow the instructions.",
     "symbol": "vyos.svg",
     "port_name_format": "eth{0}",
     "qemu": {
@@ -63,12 +63,28 @@
             "direct_download_url": "https://s3-us.vyos.io/1.2.9-S1/vyos-1.2.9-S1-amd64.iso"
         },
         {
+            "filename": "vyos-1.2.9-S1-10G-qemu.qcow2",
+            "version": "1.2.9-S1-KVM",
+            "md5sum": "0a70d78b80a3716d42487c02ef44f41f",
+            "filesize": 426967040,
+            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-s1-for-kvm",
+            "direct_download_url": "https://s3-us.vyos.io/1.2.9-S1/vyos-1.2.9-S1-10G-qemu.qcow2"
+        },
+        {
             "filename": "vyos-1.2.9-amd64.iso",
             "version": "1.2.9",
             "md5sum": "586be23b6256173e174c82d8f1f699a1",
             "filesize": 430964736,
             "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-generic-iso-image",
             "direct_download_url": "https://s3-us.vyos.io/1.2.9/vyos-1.2.9-amd64.iso"
+        },
+        {
+            "filename": "vyos-1.2.9-10G-qemu.qcow2",
+            "version": "1.2.9-KVM",
+            "md5sum": "76871c7b248c32f75177c419128257ac",
+            "filesize": 427360256,
+            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-10g-qemu-qcow2",
+            "direct_download_url": "https://s3-us.vyos.io/1.2.9/vyos-1.2.9-10G-qemu.qcow2"
         },
         {
             "filename": "vyos-1.2.8-amd64.iso",
@@ -130,10 +146,22 @@
             }
         },
         {
+            "name": "1.2.9-S1-KVM",
+            "images": {
+                "hda_disk_image": "vyos-1.2.9-S1-10G-qemu.qcow2"
+            }
+        },
+        {
             "name": "1.2.9",
             "images": {
                 "hda_disk_image": "empty8G.qcow2",
                 "cdrom_image": "vyos-1.2.9-amd64.iso"
+            }
+        },
+        {
+            "name": "1.2.9-KVM",
+            "images": {
+                "hda_disk_image": "vyos-1.2.9-10G-qemu.qcow2"
             }
         },
         {


### PR DESCRIPTION
Added the QEMU/KVM images of VyOS. The -KVM versions have the advantage that they are ready to use, no installation is required. Unfortunately, VyOS only provides these images for the old 1.2.9-S1 and 1.2.9 versions. However, they are freely available.

---

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
