### PR TITLE
Rocky Linux 9 on GNS3 needs -cpu host

### DIFF
--- a/appliances/rockylinux.gns3a
+++ b/appliances/rockylinux.gns3a
@@ -23,7 +23,7 @@
         "console_type": "telnet",
         "boot_priority": "c",
         "kvm": "require",
-        "options": "-nographic"
+        "options": "-nographic -cpu host"
     },
     "images": [
         {


### PR DESCRIPTION
RHEL 9 guest panic's during boot with following error "Fatal glibc error: CPU does not support x86-64-v2" https://access.redhat.com/solutions/6833751

Red Hat Enterprise Linux 9 on GNS3
Rocky Linux 9 on GNS3
AlmaLinux 9 on GNS3

need Additional Settings > Options: -cpu host

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ ] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
