### PR TITLE
Add Mikrotik WinBox container for GNS3

### DIFF
--- a/appliances/mikrotik-winbox.gns3a
+++ b/appliances/mikrotik-winbox.gns3a
@@ -1,0 +1,19 @@
+{
+    "appliance_id": "b770027f-1822-4ab6-b2f9-73336ca0983d",
+    "name": "Mikrotik WinBox",
+    "category": "guest",
+    "description": "Mikrotik's WinBox router management software for GNS3",
+    "vendor_name": "Mikrotik",
+    "vendor_url": "https://mikrotik.com",
+    "product_name": "Mikrotik WinBox",
+    "registry_version": 4,
+    "status": "stable",
+    "availability": "free",
+    "maintainer": "Alexander Horner",
+    "maintainer_email": "contact@alexhorner.cc",
+    "docker": {
+        "adapters": 1,
+        "image": "gns3/mikrotik-winbox",
+        "console_type": "vnc"
+    }
+}

--- a/docker/mikrotik-winbox/Dockerfile
+++ b/docker/mikrotik-winbox/Dockerfile
@@ -1,0 +1,2 @@
+FROM alexhorner/winbox-dockerised
+ENV VNC_BUILTIN_DISABLED=true

--- a/docker/mikrotik-winbox/README.rst
+++ b/docker/mikrotik-winbox/README.rst
@@ -1,0 +1,12 @@
+Mikrotik WinBox
+---------
+
+Mikrotik's WinBox router management software for GNS3 based on https://hub.docker.com/r/alexhorner/winbox-dockerised
+
+Powered by Wine + OpenBox and uses GNS3's built in VNC support.
+
+Build Instructions
+#######################
+. code:: bash
+
+    docker build -t gns3/mikrotik-winbox .


### PR DESCRIPTION
Add Mikrotik WinBox container for GNS3 based on https://github.com/alexhorner/winbox-dockerised

---

When creating a **new** appliance:
- It's tested locally, i.e.
  - [X] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [X] GNS3 VM can run it without any tweaks.
  - [X] The device is in the right category: router, switch, guest (hosts), firewall
  - [X] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [X] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [x] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*

---

Images section has been left unticked as I did not include an images section, based on referencing other container JSON files