### PR TITLE
BIRD2: New Appliance

### DIFF
--- a/appliances/bird2.gns3a
+++ b/appliances/bird2.gns3a
@@ -1,0 +1,43 @@
+{
+    "appliance_id": "8fecbf89-5cd1-4aea-b735-5f36cf0efbb7",
+    "name": "BIRD2",
+    "category": "router",
+    "description": "The BIRD project aims to develop a fully functional dynamic IP routing daemon primarily targeted on (but not limited to) Linux, FreeBSD and other UNIX-like systems and distributed under the GNU General Public License.",
+    "vendor_name": "CZ.NIC Labs",
+    "vendor_url": "https://bird.network.cz",
+    "documentation_url": "https://bird.network.cz/?get_doc&f=bird.html&v=20",
+    "product_name": "BIRD internet routing daemon",
+    "registry_version": 4,
+    "status": "stable",
+    "maintainer": "Bernhard Ehlers",
+    "maintainer_email": "dev-ehlers@mailbox.org",
+    "usage": "Username:\tgns3\nPassword:\tgns3\nTo become root, use \"sudo -s\".\n\nNetwork configuration:\nsudo nano /etc/network/interfaces\nsudo systemctl restart networking\n\nBIRD:\nRestart: sudo systemctl restart bird\nReconfigure: birdc configure",
+    "port_name_format": "eth{0}",
+    "qemu": {
+        "adapter_type": "virtio-net-pci",
+        "adapters": 4,
+        "ram": 512,
+        "hda_disk_interface": "scsi",
+        "arch": "x86_64",
+        "console_type": "telnet",
+        "kvm": "allow"
+    },
+    "images": [
+        {
+            "filename": "bird2-debian-2.0.12.qcow2",
+            "version": "2.0.12",
+            "md5sum": "435218a2e90cba921cc7fde1d64a9419",
+            "filesize": 287965184,
+            "download_url": "https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/",
+            "direct_download_url": "http://downloads.sourceforge.net/project/gns-3/Qemu%20Appliances/bird2-debian-2.0.12.qcow2"
+        }
+    ],
+    "versions": [
+        {
+            "name": "2.0.12",
+            "images": {
+                "hda_disk_image": "bird2-debian-2.0.12.qcow2"
+            }
+        }
+    ]
+}

--- a/packer/debian/README.md
+++ b/packer/debian/README.md
@@ -13,3 +13,11 @@ containing `iso_checksum_type` from debian.json.
 ```
 packer build debian.json
 ```
+
+## BIRDv2
+
+A build of Debian with BIRD Internet Routing Daemon v2 preinstalled.
+
+```
+packer build -var-file=bird2.json debian.json
+```

--- a/packer/debian/bird2.json
+++ b/packer/debian/bird2.json
@@ -1,0 +1,4 @@
+{
+    "vm_name": "bird2-debian.qcow2",
+    "setup_script": "bird2.sh"
+}

--- a/packer/debian/debian.json
+++ b/packer/debian/debian.json
@@ -1,7 +1,7 @@
 {
     "variables": {
-        "iso_url": "https://cloud.debian.org/images/cloud/bullseye/20221219-1234/debian-11-genericcloud-amd64-20221219-1234.qcow2",
-        "iso_checksum": "ba0237232247948abf7341a495dec009702809aa7782355a1b35c112e75cee81",
+        "iso_url": "https://cloud.debian.org/images/cloud/bookworm/20230612-1409/debian-12-genericcloud-amd64-20230612-1409.qcow2",
+        "iso_checksum": "9a18ee4954800113ee130b66ef24c0e27124aaf90cff1eb339f744a52354f788",
         "disk_size": "2G",
         "vm_name": "debian.qcow2",
         "setup_script": "debian.sh"
@@ -9,7 +9,7 @@
     "provisioners": [
         {
             "type": "shell",
-            "script": "scripts/remove_cloud-init_network.sh",
+            "script": "scripts/networking.sh",
             "execute_command" : "sudo env {{ .Vars }} {{ .Path }}"
         },
         {

--- a/packer/debian/scripts/bird2.sh
+++ b/packer/debian/scripts/bird2.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -ex
+
+# Install bird2 (plus telnet)
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get -y install bird2 inetutils-telnet
+chmod g+rw /etc/bird
+chmod g+rw /etc/bird/*.conf
+
+# Use traditional style interface names eth*
+sed -i '/^GRUB_CMDLINE_LINUX=/ s/"$/ net.ifnames=0"/' /etc/default/grub
+update-grub
+sed -i 's/\bens4\b/eth0/g' /etc/network/interfaces
+
+# Enable IP forwarding
+cat > /etc/sysctl.d/50-ip_forwarding.conf << 'EOF'
+# /etc/sysctl.d/50-ip_forwarding.conf - Enable IP forwarding
+
+# Uncomment the next line to enable packet forwarding for IPv4
+net.ipv4.ip_forward=1
+
+# Uncomment the next line to enable packet forwarding for IPv6
+#  Enabling this option disables Stateless Address Autoconfiguration
+#  based on Router Advertisements for this host
+net.ipv6.conf.all.forwarding=1
+EOF
+
+# Load dummy module
+echo dummy >> /etc/modules
+
+# create GNS3 user
+printf 'gns3\ngns3\n' | adduser --gecos 'GNS3' gns3
+printf '# User rules for gns3\ngns3 ALL=(ALL) NOPASSWD:ALL\n' > /etc/sudoers.d/50-gns3-user
+
+# Make BIRD easier to use
+usermod -a -G bird gns3
+cat >> /home/gns3/.profile << 'EOF'
+
+# BIRD
+alias birdc='/usr/sbin/birdc'
+alias birdcl='/usr/sbin/birdcl'
+cd /etc/bird
+EOF
+
+# Sample screen startup file
+cat > /home/gns3/.screenrc << 'EOF'
+# Disable startup message
+startup_message off
+
+# use bash as default shell
+defshell -bash
+
+# Set escape key to Ctrl+j
+#escape ^Jj
+
+# Start at window 1
+#bind c screen 1
+#bind ^c screen 1
+#bind 0 select 10
+#screen 1
+EOF
+chown gns3:gns3 /home/gns3/.screenrc

--- a/packer/debian/scripts/networking.sh
+++ b/packer/debian/scripts/networking.sh
@@ -1,6 +1,21 @@
 #!/bin/sh
 set -ex
 
+# add hostname into /etc/hosts
+if [ -z "$(hostname -d)" ]; then
+	printf '127.0.1.1\t%s\n' "$(hostname)" >> /etc/hosts
+else
+	printf '127.0.1.1\t%s\t%s\n' "$(hostname -f)" "$(hostname)" >> /etc/hosts
+fi
+
+# replace systemd-resolved by resolvconf
+cp /etc/resolv.conf /etc/resolv.conf.orig
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get -y install --purge ifupdown resolvconf
+cat /etc/resolv.conf.orig > /etc/resolv.conf
+rm -f /etc/resolv.conf.orig
+
 # replace cloud-init network configuration
 cat > /etc/network/interfaces <<'EOF'
 # This file describes the network interfaces available on your system

--- a/packer/debian/scripts/post_setup.sh
+++ b/packer/debian/scripts/post_setup.sh
@@ -3,6 +3,7 @@ set -ex
 
 # clear repository
 apt-get clean
+rm -rf /var/lib/apt/lists/*
 
 # clear unused space
 echo 'Clearing unused space...'


### PR DESCRIPTION
This is my BIRD2 appliance, based on Debian 12 (Bookworm), as announced in issue [#501](https://github.com/GNS3/gns3-registry/issues/501#issuecomment-1567466046). It replaces the outdated BIRD appliance.

I set the image location to <http://downloads.sourceforge.net/project/gns-3/Qemu%20Appliances/bird2-debian-2.0.12.qcow2>.

As I can't upload to that location, I put it temporarily in <https://github.com/b-ehlers/gns3-registry/releases/download/BIRD2/bird2-debian-2.0.12.qcow2>, @grossmj please upload it to the final location.

---

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ ] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [x] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [x] GNS3 VM can run it without any tweaks.
  - [x] The device is in the right category: router, switch, guest (hosts), firewall
  - [x] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [x] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [x] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
