### PR TITLE
ipterm: Update to Debian 12 (bookworm)

### DIFF
--- a/appliances/ipterm.gns3a
+++ b/appliances/ipterm.gns3a
@@ -8,8 +8,8 @@
     "product_name": "ipterm",
     "registry_version": 4,
     "status": "stable",
-    "maintainer": "GNS3 Team",
-    "maintainer_email": "developers@gns3.net",
+    "maintainer": "Bernhard Ehlers",
+    "maintainer_email": "dev-ehlers@mailbox.org",
     "usage": "The /root directory is persistent.",
     "symbol": "linux_guest.svg",
     "docker": {

--- a/appliances/webterm.gns3a
+++ b/appliances/webterm.gns3a
@@ -8,8 +8,8 @@
     "product_name": "webterm",
     "registry_version": 4,
     "status": "stable",
-    "maintainer": "GNS3 Team",
-    "maintainer_email": "developers@gns3.net",
+    "maintainer": "Bernhard Ehlers",
+    "maintainer_email": "dev-ehlers@mailbox.org",
     "usage": "The /root directory is persistent.",
     "symbol": "firefox.svg",
     "docker": {

--- a/docker/docker_images
+++ b/docker/docker_images
@@ -4,10 +4,9 @@
 
 # chromium: base image is updated too often, use manual build on base updates
 chromium		chromium	NONE
-# ipterm: base image debian:jessie too old
-#ipterm-base		ipterm/base
-#ipterm			ipterm/cli
-#webterm		ipterm/web
+ipterm-base		ipterm/base
+ipterm			ipterm/cli
+webterm			ipterm/web
 jupyter:v2		jupyter
 jupyter27:v2		jupyter-2.7
 # kalilinux: base image is updated too often, use manual build on base updates
@@ -15,7 +14,7 @@ kalilinux		kalilinux	NONE
 mikrotik-winbox		mikrotik-winbox
 # ostinato-wireshark: failed to build: mesa-dri-swrast - no such package
 #ostinato-wireshark	ostinato-wireshark
-openvswitch		openvswitch			
+openvswitch		openvswitch
 ovs-snmp		ovs-snmp			--platform=linux/arm64
 pyats			pyats
 ubuntu:focal		ubuntu

--- a/docker/ipterm/README.md
+++ b/docker/ipterm/README.md
@@ -41,11 +41,11 @@ docker push gns3/ipterm-base    (optional)
 Afterwards the cli and/or the web image can be built:
 
 ```
-docker build -t gns3/ipterm cli
+docker build --build-arg DOCKER_REPOSITORY=gns3 -t gns3/ipterm cli
 docker push gns3/ipterm
 ```
 
 ```
-docker build -t gns3/webterm web
+docker build --build-arg DOCKER_REPOSITORY=gns3 -t gns3/webterm web
 docker push gns3/webterm
 ```

--- a/docker/ipterm/base/Dockerfile
+++ b/docker/ipterm/base/Dockerfile
@@ -1,29 +1,32 @@
 # docker base image for basic networking tools
 
-FROM debian:jessie
+## Stage 1 - compile mtools (msend & mreceive)
+FROM debian:bookworm-slim
 
-RUN set -ex \
+RUN set -e -x \
+    && cd /root \
+    && export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
-#
-# compile and install mtools (msend & mreceive)
-#
-    && dpkg-query -f '${binary:Package}\n' -W | sort > base_packages \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+    && apt-get -y --no-install-recommends install \
         gcc libc6-dev make curl ca-certificates \
-    && curl -OL https://github.com/troglobit/mtools/releases/download/v2.3/mtools-2.3.tar.gz \
+    && curl -s -S -L -O https://github.com/troglobit/mtools/releases/download/v2.3/mtools-2.3.tar.gz \
     && tar xfz mtools-2.3.tar.gz \
     && cd mtools-2.3 \
     && make \
-    && make install \
-    && cd .. \
-    && rm -r mtools-2.3* \
-    && dpkg-query -f '${binary:Package}\n' -W | sort > packages \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y purge \
-        `comm -13 base_packages packages` \
-    && rm -f base_packages packages \
-#
-# install remaining tools
-#
-    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
-        net-tools tcpdump telnet traceroute curl iperf3 knot-host openssh-client mtr-tiny socat nano vim-tiny \
+    && make install
+
+## Stage 2 - Main image
+FROM debian:bookworm-slim
+
+COPY --from=0 /usr/local/sbin/* /usr/local/bin/
+
+RUN set -e -x \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get -y --no-install-recommends install \
+        dumb-init curl ca-certificates iperf3 knot-host \
+        mtr-tiny openssh-client socat tcpdump \
+        net-tools iproute2 ifupdown iputils-ping \
+        telnet traceroute procps nano vim-tiny \
+    && ln -s /usr/bin/khost /usr/local/bin/host \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/ipterm/cli/Dockerfile
+++ b/docker/ipterm/cli/Dockerfile
@@ -1,9 +1,24 @@
 # docker image with basic networking tools
 
-FROM gns3/ipterm-base
+ARG DOCKER_REPOSITORY
+FROM $DOCKER_REPOSITORY/ipterm-base
 
-# add a dummy layer to get an updated container timestamp
-RUN /bin/true
+#
+# startup script
+#
+RUN printf '\
+\043!/bin/sh\n\
+[ $$ -eq 1 ] && exec dumb-init -- "$0" "$@"\n\
+\n\
+[ -f /root/init.sh ] && [ -x /root/init.sh ] && /root/init.sh\n\
+\n\
+cd\n\
+if [ $# -gt 0 ]; then\n\
+	"$@"\n\
+else\n\
+	bash -i -l\n\
+fi\n' \
+        > /etc/init.sh && chmod +x /etc/init.sh
 
+ENTRYPOINT [ "/etc/init.sh" ]
 VOLUME [ "/root" ]
-CMD [ "sh", "-c", "cd; exec bash -i" ]

--- a/docker/ipterm/cli/README.md
+++ b/docker/ipterm/cli/README.md
@@ -24,6 +24,6 @@ This appliance contains the following networking tools:
 Before ipterm-base has to be build.
 
 ```
-docker build -t gns3/ipterm .
+docker build --build-arg DOCKER_REPOSITORY=gns3 -t gns3/ipterm .
 docker push gns3/ipterm
 ```

--- a/docker/ipterm/web/Dockerfile
+++ b/docker/ipterm/web/Dockerfile
@@ -1,59 +1,93 @@
-# docker image with basic networking tools and web browser
+# docker image with firefox web browser and basic networking tools
 
-FROM gns3/ipterm-base
+ARG DOCKER_REPOSITORY
+FROM $DOCKER_REPOSITORY/ipterm-base
 
-# minimal init, see https://github.com/Yelp/dumb-init
-ADD https://github.com/Yelp/dumb-init/releases/download/v1.1.1/dumb-init_1.1.1_amd64 /usr/local/sbin/dumb-init
-
-RUN set -ex \
-    && chmod 755 /usr/local/sbin/dumb-init \
-    && apt-get update \
+RUN set -e -x \
 #
 # install web tools
 #
-    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
-        firefox-esr lxterminal jwm menu leafpad apache2-utils \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get -y --no-install-recommends install \
+        firefox-esr lxterminal jwm menu xfe wmctrl \
     && rm -rf /var/lib/apt/lists/* \
-    && /bin/echo -e '\
-\x23!/bin/sh\n\
-\n\
-\x23 use home page on first start\n\
-[ -e "$HOME/.mozilla" ] || start_url="about:home"\n\
-\n\
-\x23 start firefox\n\
-start=$(date +%s)\n\
-firefox $start_url\n\
-status=$?\n\
-\n\
-\x23 workaround: restart firefox, if it crashes during initialization\n\
-if [ $status -eq 139 -a $(($(date +%s)-start)) -le 10 ]; then\n\
-	firefox $start_url\n\
-fi' \
-        > /usr/local/bin/start-firefox && chmod +x /usr/local/bin/start-firefox \
-    && /bin/echo -e '\
+#
+# update firefox preferences
+#
+    && printf '\n\
+// Disable welcome page on first start and when showing about:home\n\
+pref("browser.startup.homepage_override.mstone","ignore");\n\
+pref("trailhead.firstrun.branches", "nofirstrun-empty");\n' \
+	>> /etc/firefox-esr/firefox-esr.js \
+#
+# customize jwm menu
+#
+    && printf '\
 ?package(firefox-esr):\\\n\
  needs="x11"\\\n\
  section="Applications"\\\n\
  title="Mozilla Firefox"\\\n\
- command="start-firefox"' \
+ command="firefox"\n' \
         > /etc/menu/firefox \
-    && echo "postrun="\""sed -i '/^    </ d' debian-menu"\" >> /etc/menu-methods/jwm \
+    && printf '\
+?package(xfe):\\\n\
+ needs="x11"\\\n\
+ section="/"\\\n\
+ title="File Manager"\\\n\
+ command="xfe"\n' \
+        > /etc/menu/xfe \
+    && printf '\
+?package(xfe):\\\n\
+ needs="x11"\\\n\
+ section="Applications/TextEditor"\\\n\
+ title="X File Write"\\\n\
+ command="xfwrite"\n' \
+        > /etc/menu/xfwrite \
+    && echo "postrun=\"sed -i '/^    </ d' debian-menu\"" >> /etc/menu-methods/jwm \
     && sed -i 's/\(Desktops width\)="[0-9]*"/\1="2"/' /etc/jwm/system.jwmrc \
+    && sed -i '/<Font>/ s/-[0-9]\+/-10/' /etc/jwm/system.jwmrc \
+    && sed -i 's/xterm/x-terminal-emulator/g' /etc/jwm/system.jwmrc \
     && update-menus \
+#
+# set lxterminal defaults
+#
     && mkdir -p /root/.config/lxterminal \
-    && /bin/echo -e '\
+    && printf '\
 [general]\n\
 scrollback=1000\n\
-fgcolor=#ffffff' \
+fgcolor=#ffffff\n' \
         > /root/.config/lxterminal/lxterminal.conf \
-    && /bin/echo -e '\
-\x23!/bin/sh\n\
-[ $$ -eq 1 ] && exec dumb-init "$0" "$@"\n\
+#
+# set xfe defaults
+#
+    && mkdir -p /root/.config/xfe \
+    && printf '\
+[OPTIONS]\n\
+root_warn=0\n\
+\n\
+[PROGS]\n\
+xterm=x-terminal-emulator\n' \
+        > /root/.config/xfe/xferc \
+#
+# startup script
+#
+    && printf '\
+\043!/bin/sh\n\
+[ $$ -eq 1 ] && exec dumb-init -- "$0" "$@"\n\
 \n\
 cd\n\
 export SHELL=/bin/bash\n\
-start-firefox &\n\
-jwm' \
+\n\
+\043 start firefox\n\
+firefox &\n\
+\n\
+\043 start a windows manager if none is active\n\
+if wmctrl -m > /dev/null 2>&1; then\n\
+	wait $!\n\
+else\n\
+	jwm\n\
+fi\n' \
         > /etc/init.sh && chmod +x /etc/init.sh
 
 VOLUME [ "/root" ]

--- a/docker/ipterm/web/README.md
+++ b/docker/ipterm/web/README.md
@@ -20,11 +20,20 @@ This appliance contains the following networking tools:
 - mtools (multicast tools msend & mreceive),
   see https://github.com/troglobit/mtools
 
+This appliance is optimized to run within GNS3.
+To run it locally use xhost to allow access to X and
+then start the image.
+
+```text
+xhost +local:
+docker run -it --ipc=host -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix gns3/webterm
+```
+
 ## Build and publish the Images
 
 Before ipterm-base has to be build.
 
 ```
-docker build -t gns3/webterm .
+docker build --build-arg DOCKER_REPOSITORY=gns3 -t gns3/webterm .
 docker push gns3/webterm
 ```


### PR DESCRIPTION
As announced in #770 here the updated ipterm and webterm appliances. They are based on Debian 12 (Bookworm).

---

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
