### PR TITLE
chromium: Create data directory in Dockerfile

### DIFF
--- a/docker/chromium/Dockerfile
+++ b/docker/chromium/Dockerfile
@@ -1,7 +1,7 @@
 FROM jess/chromium
 MAINTAINER developers@gns3.net
 
-# add a dummy layer to get an updated container timestamp
-RUN /bin/true
+RUN mkdir -p /home/chromium/data
 
-VOLUME /data
+CMD [ "--user-data-dir=/home/chromium/data" ]
+VOLUME /home/chromium/data


### PR DESCRIPTION
Community issue: <https://gns3.com/community/featured/does-the-docker-gns3-chromium-work>

The reason is, that `jess/chromium`, the base of `chromium`, runs as an unprivileged user, but doesn't create the data directory. GNS3 starts a container always as root and therefore creates non-existent volume directories with owner root. Later it switches to the unprivileged user. But this user has no permission to use this freshly created volume directory.

Workaround: Create the data directory in the Dockerfile.

---

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
