### PR TITLE
ostinato-wireshark - Fix install of mesa-dri-swrast

### DIFF
--- a/docker/docker_images
+++ b/docker/docker_images
@@ -12,8 +12,7 @@ jupyter27:v2		jupyter-2.7
 # kalilinux: base image is updated too often, use manual build on base updates
 kalilinux		kalilinux	NONE
 mikrotik-winbox		mikrotik-winbox
-# ostinato-wireshark: failed to build: mesa-dri-swrast - no such package
-#ostinato-wireshark	ostinato-wireshark
+ostinato-wireshark	ostinato-wireshark
 openvswitch		openvswitch
 ovs-snmp		ovs-snmp			--platform=linux/arm64
 pyats			pyats

--- a/docker/ostinato-wireshark/Dockerfile
+++ b/docker/ostinato-wireshark/Dockerfile
@@ -18,7 +18,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositori
 	ostinato-gui \
 	xterm wget \
 	font-adobe-100dpi \
- 	mesa-dri-swrast \
+	mesa-dri-gallium \
 	ca-certificates \
 	curl \
 	openssl \
@@ -44,6 +44,7 @@ COPY Ostinato.desktop /home/gns3/.config/autostart
 COPY Ostinato.desktop /home/gns3/Desktop/Ostinato.desktop
 COPY Wireshark.desktop /home/gns3/Desktop/Wireshark.desktop
 RUN  sudo chmod 775 /home/gns3/Desktop/Ostinato.desktop
+RUN  sudo chmod 775 /home/gns3/Desktop/Wireshark.desktop
 RUN  sudo chown gns3:gns3 /home/gns3/Desktop/
 RUN  sudo chown gns3:gns3 /home/gns3/Desktop/Ostinato.desktop
 RUN  sudo chown gns3:gns3 /home/gns3/.config/autostart


### PR DESCRIPTION
Fix build of ostinato-wireshark docker image. Previuosly it uses the package `mesa-dri-swrast`, which is outdated since alpine v3.12 (mid 2020). The files from that package are now in the `mesa-dri-gallium` package. By using this new package the build works (at least locally) and a short test was successful.

Furthermore Wireshark.desktop was not executable, that is also fixed.

---

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
