### PR TITLE
Docker build: better get_image_version()

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -96,9 +96,10 @@ jobs:
 
           # get image version
           get_image_version() {
+            local object
+            object='config.Labels."org.opencontainers.image.version"'
             docker buildx imagetools inspect --format '{{json .Image}}' "$1" | \
-              sed -n 's/^ *"org\.opencontainers\.image\.version": *"\([^"]*\).*/\1/p' | \
-              head -n 1
+              jq -r ".$object // .\"linux/amd64\".$object // empty"
           }
 
           # special treatment for kalilinux: rebuild when image version changes


### PR DESCRIPTION
Previously `sed` was used to parse the json formatted image information. This works in the actual case, because the json data is nicely formatted. But for a more robust parsing the program `jq` is far better suited. All GitHub runners include the `jq` program, not only Ubuntu, but also the Windows and macOS ones.