### PR TITLE
chromium - Include base Dockerfile

### DIFF
--- a/docker/chromium/Dockerfile
+++ b/docker/chromium/Dockerfile
@@ -1,4 +1,63 @@
-FROM jess/chromium
+###FROM jess/chromium
+
+### Included Dockerfile of jess/chromium
+### https://github.com/jessfraz/dockerfiles/blob/master/chromium/Dockerfile
+
+# Run Chromium in a container
+#
+# docker run -it \
+#	--net host \ # may as well YOLO
+#	--cpuset-cpus 0 \ # control the cpu
+#	--memory 512mb \ # max memory it can use
+#	-v /tmp/.X11-unix:/tmp/.X11-unix \ # mount the X11 socket
+#	-e DISPLAY=unix$DISPLAY \
+#	-v $HOME/Downloads:/home/chromium/Downloads \
+#	-v $HOME/.config/chromium/:/data \ # if you want to save state
+#	--security-opt seccomp=$HOME/chrome.json \
+#	--device /dev/snd \ # so we have sound
+#	-v /dev/shm:/dev/shm \
+#	--name chromium \
+#	jess/chromium
+#
+# You will want the custom seccomp profile:
+# 	wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json -O ~/chrome.json
+
+# Base docker image
+FROM debian:bullseye-slim
+LABEL maintainer "Jessie Frazelle <jess@linux.com>"
+
+# Install Chromium
+# Yes, including the Google API Keys sucks but even debian does the same: https://packages.debian.org/stretch/amd64/chromium/filelist
+RUN apt-get update && apt-get install -y \
+      chromium \
+      chromium-l10n \
+      fonts-liberation \
+      fonts-roboto \
+      hicolor-icon-theme \
+      libcanberra-gtk-module \
+      libexif-dev \
+      libgl1-mesa-dri \
+      libgl1-mesa-glx \
+      libpangox-1.0-0 \
+      libv4l-0 \
+      fonts-symbola \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /etc/chromium.d/ \
+    && /bin/echo -e 'export GOOGLE_API_KEY="AIzaSyCkfPOPZXDKNn8hhgu3JrA62wIgC93d44k"\nexport GOOGLE_DEFAULT_CLIENT_ID="811574891467.apps.googleusercontent.com"\nexport GOOGLE_DEFAULT_CLIENT_SECRET="kdloedMFGdGla2P1zacGjAQh"' > /etc/chromium.d/googleapikeys
+
+# Add chromium user
+RUN groupadd -r chromium && useradd -r -g chromium -G audio,video chromium \
+    && mkdir -p /home/chromium/Downloads && chown -R chromium:chromium /home/chromium
+
+# Run as non privileged user
+USER chromium
+
+ENTRYPOINT [ "/usr/bin/chromium" ]
+CMD [ "--user-data-dir=/data" ]
+
+### End of included Dockerfile
+
 MAINTAINER developers@gns3.net
 
 RUN mkdir -p /home/chromium/data

--- a/docker/chromium/README.rst
+++ b/docker/chromium/README.rst
@@ -1,5 +1,5 @@
 Chromium
 ---------
 
-Chromium for GNS3 based on https://hub.docker.com/r/jess/chromium
-with persistent data.
+Chromium for GNS3 with persistent data, based on
+https://github.com/jessfraz/dockerfiles/tree/master/chromium

--- a/docker/docker_images
+++ b/docker/docker_images
@@ -2,8 +2,7 @@
 
 --platform=linux/amd64					# global options
 
-# chromium: base image is updated too often, use manual build on base updates
-chromium		chromium	NONE
+chromium		chromium
 ipterm-base		ipterm/base
 ipterm			ipterm/cli
 webterm			ipterm/web


### PR DESCRIPTION
All docker images of jess (<https://hub.docker.com/u/jess>) haven't been updated since one month. On github I created an issue https://github.com/jessfraz/dockerfiles/issues/594, but no reaction. Since more than 2 years there are no actions in this repository, so I assume it is dead.

Therefore I included the Dockerfile from https://github.com/jessfraz/dockerfiles and let it build with our build system.

A nice additional benefit is, that the base image is now the Debian image, not the constantly changing jess/chromium. It can now use the normal build options.