### PR TITLE
Add endhost and haproxy appliances

### DIFF
--- a/appliances/endhost.gns3a
+++ b/appliances/endhost.gns3a
@@ -1,0 +1,17 @@
+{
+    "appliance_id": "f59a5cf6-baaa-45a6-9685-989a2c3f3f4a",
+    "name": "endhost",
+    "category": "guest",
+    "description": "General purpose alpine-based endhost",
+    "vendor_name": "endhost",
+    "vendor_url": "https://www.alpinelinux.org",
+    "product_name": "endhost",
+    "registry_version": 4,
+    "status": "experimental",
+    "maintainer": "GNS3 Team",
+    "maintainer_email": "developers@gns3.net",
+    "docker": {
+        "adapters": 1,
+        "image": "gns3/endhost:latest"
+    }
+}

--- a/appliances/haproxy.gns3a
+++ b/appliances/haproxy.gns3a
@@ -1,0 +1,18 @@
+{
+    "appliance_id": "79df483d-8cc9-48de-85ea-e6cb45b93e2a",
+    "name": "haproxy",
+    "category": "guest",
+    "description": "haproxy alpine container",
+    "vendor_name": "haproxy",
+    "vendor_url": "https://www.haproxy.org",
+    "product_name": "haproxy",
+    "registry_version": 4,
+    "status": "experimental",
+    "maintainer": "GNS3 Team",
+    "maintainer_email": "developers@gns3.net",
+    "usage": "Modify /etc/haproxy/haproxy.cfg to suit your needs.",
+    "docker": {
+        "adapters": 1,
+        "image": "gns3/haproxy:latest"
+    }
+}

--- a/docker/docker_images
+++ b/docker/docker_images
@@ -3,6 +3,8 @@
 --platform=linux/amd64					# global options
 
 chromium		chromium
+endhost			endhost
+haproxy			haproxy
 ipterm-base		ipterm/base
 ipterm			ipterm/cli
 webterm			ipterm/web
@@ -23,10 +25,6 @@ xeyes			xeyes
 #
 # The following images are not used by any appliance
 #
-
-# AJ Nouri
-#endhost		endhost
-#haproxy		haproxy
 
 # GNS3 Developers
 #dhcp			dhcp

--- a/docker/haproxy/haproxy.cfg
+++ b/docker/haproxy/haproxy.cfg
@@ -8,7 +8,6 @@ global
     user        haproxy
     group       haproxy
     #daemon
-    debug
 
 #---------------------------------------------------------------------
 # common defaults that all the 'listen' and 'backend' sections will


### PR DESCRIPTION
Basic appliances for endhost and haproxy.

---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [x] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [x] GNS3 VM can run it without any tweaks.
  - [x] The device is in the right category: router, switch, guest (hosts), firewall
  - [x] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [x] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [x] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
