### PR TITLE
Updating Fedora Cloud, CentOS-Stream, & RHEL Appliance Images

### DIFF
--- a/appliances/centos-cloud.gns3a
+++ b/appliances/centos-cloud.gns3a
@@ -27,6 +27,22 @@
     },
     "images": [
         {
+            "filename": "CentOS-Stream-GenericCloud-9-20230727.1.x86_64.qcow2",
+            "version": "Stream-9 (20230727.1)",
+            "md5sum": "b66b7e4951cb5491ae44d5616d56b7cf",
+            "filesize": 1128764416,
+            "download_url": "https://cloud.centos.org/centos/9-stream/x86_64/images",
+            "direct_download_url": "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230727.1.x86_64.qcow2"
+        },
+        {
+            "filename": "CentOS-Stream-GenericCloud-8-20230710.0.x86_64.qcow2",
+            "version": "Stream-8 (20230710.0)",
+            "md5sum": "83e02ce98c29753c86fb7be7d802aa75",
+            "filesize": 1676164096,
+            "download_url": "https://cloud.centos.org/centos/8-stream/x86_64/images",
+            "direct_download_url": "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20230710.0.x86_64.qcow2"
+        },
+        {
             "filename": "CentOS-8-GenericCloud-8.4.2105-20210603.0.x86_64.qcow2",
             "version": "8.4 (2105)",
             "md5sum": "032eed270415526546eac07628905a62",
@@ -60,6 +76,20 @@
         }
     ],
     "versions": [
+        {
+            "name": "Stream-9 (20230727.1)",
+            "images": {
+                "hda_disk_image": "CentOS-Stream-GenericCloud-9-20230727.1.x86_64.qcow2",
+                "cdrom_image": "centos-cloud-init-data.iso"
+            }
+        },
+        {
+            "name": "Stream-8 (20230710.0)",
+            "images": {
+                "hda_disk_image": "CentOS-Stream-GenericCloud-8-20230710.0.x86_64.qcow2",
+                "cdrom_image": "centos-cloud-init-data.iso"
+            }
+        },
         {
             "name": "8.4 (2105)",
             "images": {

--- a/appliances/fedora-cloud.gns3a
+++ b/appliances/fedora-cloud.gns3a
@@ -69,28 +69,28 @@
     ],
     "versions": [
         {
-            "name": "Fedora-Cloud 38-1.6",
+            "name": "38-1.6",
             "images": {
                 "hda_disk_image": "Fedora-Cloud-Base-38-1.6.x86_64.qcow2",
                 "cdrom_image": "fedora-cloud-init-data.iso"
             }
         },
         {
-            "name": "Fedora-Cloud 37-1.7",
+            "name": "37-1.7",
             "images": {
                 "hda_disk_image": "Fedora-Cloud-Base-37-1.7.x86_64.qcow2",
                 "cdrom_image": "fedora-cloud-init-data.iso"
             }
         },
         {
-            "name": "Fedora-Cloud 36-1.5",
+            "name": "36-1.5",
             "images": {
                 "hda_disk_image": "Fedora-Cloud-Base-36-1.5.x86_64.qcow2",
                 "cdrom_image": "fedora-cloud-init-data.iso"
             }
         },
         {
-            "name": "Fedora-Cloud 35-1.2",
+            "name": "35-1.2",
             "images": {
                 "hda_disk_image": "Fedora-Cloud-Base-35-1.2.x86_64.qcow2",
                 "cdrom_image": "fedora-cloud-init-data.iso"

--- a/appliances/fedora-cloud.gns3a
+++ b/appliances/fedora-cloud.gns3a
@@ -27,20 +27,12 @@
     },
     "images": [
         {
-            "filename": "Fedora-Cloud-Base-35-1.2.x86_64.qcow2",
-            "version": "35-1.2",
-            "md5sum": "cfa9cdcfb946e5f4cf9dd4d7906008d0",
-            "filesize": 376897536,
-            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images",
-            "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2"
-        },
-        {
-            "filename": "Fedora-Cloud-Base-36-1.5.x86_64.qcow2",
-            "version": "36-1.5",
-            "md5sum": "7f7cdad25b77f232078bf454c39529d3",
-            "filesize": 448266240,
-            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images",
-            "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2"
+            "filename": "Fedora-Cloud-Base-38-1.6.x86_64.qcow2",
+            "version": "38-1.6",
+            "md5sum": "53ddfe7b28666d5ddc55e93ff06abad2",
+            "filesize": 497287168,
+            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images",
+            "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
         },
         {
             "filename": "Fedora-Cloud-Base-37-1.7.x86_64.qcow2",
@@ -51,12 +43,20 @@
             "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images/Fedora-Cloud-Base-37-1.7.x86_64.qcow2"
         },
         {
-            "filename": "Fedora-Cloud-Base-38-1.6.x86_64.qcow2",
-            "version": "38-1.6",
-            "md5sum": "53ddfe7b28666d5ddc55e93ff06abad2",
-            "filesize": 497287168,
-            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images",
-            "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
+            "filename": "Fedora-Cloud-Base-36-1.5.x86_64.qcow2",
+            "version": "36-1.5",
+            "md5sum": "7f7cdad25b77f232078bf454c39529d3",
+            "filesize": 448266240,
+            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images",
+            "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2"
+        },
+        {
+            "filename": "Fedora-Cloud-Base-35-1.2.x86_64.qcow2",
+            "version": "35-1.2",
+            "md5sum": "cfa9cdcfb946e5f4cf9dd4d7906008d0",
+            "filesize": 376897536,
+            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images",
+            "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2"
         },
         {
             "filename": "fedora-cloud-init-data.iso",

--- a/appliances/fedora-cloud.gns3a
+++ b/appliances/fedora-cloud.gns3a
@@ -35,6 +35,30 @@
             "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2"
         },
         {
+            "filename": "Fedora-Cloud-Base-36-1.5.x86_64.qcow2",
+            "version": "36-1.5",
+            "md5sum": "7f7cdad25b77f232078bf454c39529d3",
+            "filesize": 448266240,
+            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images",
+            "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2"
+        },
+        {
+            "filename": "Fedora-Cloud-Base-37-1.7.x86_64.qcow2",
+            "version": "37-1.7",
+            "md5sum": "36f7b464b6ab46ad97c001b539495e90",
+            "filesize": 492830720,
+            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images",
+            "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images/Fedora-Cloud-Base-37-1.7.x86_64.qcow2"
+        },
+        {
+            "filename": "Fedora-Cloud-Base-38-1.6.x86_64.qcow2",
+            "version": "38-1.6",
+            "md5sum": "53ddfe7b28666d5ddc55e93ff06abad2",
+            "filesize": 497287168,
+            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images",
+            "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
+        },
+        {
             "filename": "fedora-cloud-init-data.iso",
             "version": "1.0",
             "md5sum": "3d0d6391d3f5ece1180c70b9667c4dca",
@@ -45,7 +69,28 @@
     ],
     "versions": [
         {
-            "name": "35-1.2",
+            "name": "Fedora-Cloud 38-1.6",
+            "images": {
+                "hda_disk_image": "Fedora-Cloud-Base-38-1.6.x86_64.qcow2",
+                "cdrom_image": "fedora-cloud-init-data.iso"
+            }
+        },
+        {
+            "name": "Fedora-Cloud 37-1.7",
+            "images": {
+                "hda_disk_image": "Fedora-Cloud-Base-37-1.7.x86_64.qcow2",
+                "cdrom_image": "fedora-cloud-init-data.iso"
+            }
+        },
+        {
+            "name": "Fedora-Cloud 36-1.5",
+            "images": {
+                "hda_disk_image": "Fedora-Cloud-Base-36-1.5.x86_64.qcow2",
+                "cdrom_image": "fedora-cloud-init-data.iso"
+            }
+        },
+        {
+            "name": "Fedora-Cloud 35-1.2",
             "images": {
                 "hda_disk_image": "Fedora-Cloud-Base-35-1.2.x86_64.qcow2",
                 "cdrom_image": "fedora-cloud-init-data.iso"

--- a/appliances/rhel.gns3a
+++ b/appliances/rhel.gns3a
@@ -13,7 +13,7 @@
     "availability": "service-contract",
     "maintainer": "Neyder Achahuanco",
     "maintainer_email": "neyder@neyder.net",
-    "usage": "You should download Red Hat Enterprise Linux KVM Guest Image from https://access.redhat.com/downloads/content/479/ver=/rhel---8/8.5/x86_64/product-software attach/customize cloud-init.iso and start.\nusername: cloud-user\npassword: redhat",
+    "usage": "You should download Red Hat Enterprise Linux KVM Guest Image from https://access.redhat.com/downloads/content/479/ver=/rhel---9/9.2/x86_64/product-software attach/customize cloud-init.iso and start.\nusername: cloud-user\npassword: redhat",
     "qemu": {
         "adapter_type": "virtio-net-pci",
         "adapters": 1,
@@ -26,6 +26,48 @@
         "options": "-nographic"
     },
     "images": [
+        {
+            "filename": "rhel-9.2-x86_64-kvm.qcow2",
+            "version": "9.2",
+            "md5sum": "f33845298b387dbcfbf162c6b4e3f8c8",
+            "filesize": 819265536,
+            "download_url": "https://access.redhat.com/downloads/content/479/ver=/rhel---8/9.2/x86_64/product-software"
+        },
+        {
+            "filename": "rhel-baseos-9.1-x86_64-kvm.qcow2",
+            "version": "9.1",
+            "md5sum": "622de743da83bcec1ad2959ecaedb8f4",
+            "filesize": 753401856,
+            "download_url": "https://access.redhat.com/downloads/content/479/ver=/rhel---8/9.1/x86_64/product-software"
+        },
+        {
+            "filename": "rhel-baseos-9.0-x86_64-kvm.qcow2",
+            "version": "9.0",
+            "md5sum": "4a41497d354fe99a4abf55f1ed73edcb",
+            "filesize": 696582144,
+            "download_url": "https://access.redhat.com/downloads/content/479/ver=/rhel---8/9.0/x86_64/product-software"
+        },
+        {
+            "filename": "rhel-8.8-x86_64-kvm.qcow2",
+            "version": "8.8",
+            "md5sum": "bf22af816ba6abd846bbb0c9ecf7bce1",
+            "filesize": 926810112,
+            "download_url": "https://access.redhat.com/downloads/content/479/ver=/rhel---8/8.8/x86_64/product-software"
+        },
+        {
+            "filename": "rhel-8.7-x86_64-kvm.qcow2",
+            "version": "8.7",
+            "md5sum": "ab71a2c4cc276441bf999f531e064507",
+            "filesize": 858128384,
+            "download_url": "https://access.redhat.com/downloads/content/479/ver=/rhel---8/8.7/x86_64/product-software"
+        },
+        {
+            "filename": "rhel-8.6-x86_64-kvm.qcow2",
+            "version": "8.6",
+            "md5sum": "19501666f46df6b5472db1254e86a339",
+            "filesize": 832438272,
+            "download_url": "https://access.redhat.com/downloads/content/479/ver=/rhel---8/8.6/x86_64/product-software"
+        },
         {
             "filename": "rhel-8.5-x86_64-kvm.qcow2",
             "version": "8.5",
@@ -70,6 +112,48 @@
         }
     ],
     "versions": [
+        {
+            "name": "9.2",
+            "images": {
+                "hda_disk_image": "rhel-9.2-x86_64-kvm.qcow2",
+                "cdrom_image": "rhel-cloud-init.iso"
+            }
+        },
+        {
+            "name": "9.1",
+            "images": {
+                "hda_disk_image": "rhel-baseos-9.1-x86_64-kvm.qcow2",
+                "cdrom_image": "rhel-cloud-init.iso"
+            }
+        },
+        {
+            "name": "9.0",
+            "images": {
+                "hda_disk_image": "rhel-baseos-9.0-x86_64-kvm.qcow2",
+                "cdrom_image": "rhel-cloud-init.iso"
+            }
+        },
+        {
+            "name": "8.8",
+            "images": {
+                "hda_disk_image": "rhel-8.8-x86_64-kvm.qcow2",
+                "cdrom_image": "rhel-cloud-init.iso"
+            }
+        },
+        {
+            "name": "8.7",
+            "images": {
+                "hda_disk_image": "rhel-8.7-x86_64-kvm.qcow2",
+                "cdrom_image": "rhel-cloud-init.iso"
+            }
+        },
+        {
+            "name": "8.6",
+            "images": {
+                "hda_disk_image": "rhel-8.6-x86_64-kvm.qcow2",
+                "cdrom_image": "rhel-cloud-init.iso"
+            }
+        },
         {
             "name": "8.5",
             "images": {


### PR DESCRIPTION
Adding Fedora Cloud 36, Fedora Cloud 37, & Fedora Cloud 38

---
When updating an **existing** appliance:
- [Y] The new version is on top.
- [Y] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [Y] If you forked the repo, running check.py doesn't drop any errors for the updated file.

