### PR TITLE
fix huawei ce12800 and ne40 unsupported machine type error

### DIFF
--- a/appliances/huawei-ce12800.gns3a
+++ b/appliances/huawei-ce12800.gns3a
@@ -21,7 +21,7 @@
         "arch": "x86_64",
         "console_type": "telnet",
         "kvm": "require",
-        "options": "-machine type=pc-1.0,accel=kvm -serial mon:stdio -nographic -nodefaults -rtc base=utc -cpu host"
+        "options": "-machine type=pc,accel=kvm -serial mon:stdio -nographic -nodefaults -rtc base=utc -cpu host"
     },
     "images": [
         {

--- a/appliances/huawei-ne40e.gns3a
+++ b/appliances/huawei-ne40e.gns3a
@@ -23,7 +23,7 @@
         "arch": "x86_64",
         "console_type": "telnet",
         "kvm": "require",
-        "options": "-machine type=pc-1.0,accel=kvm -serial mon:stdio -nographic -nodefaults -rtc base=utc -cpu host"
+        "options": "-machine type=pc,accel=kvm -serial mon:stdio -nographic -nodefaults -rtc base=utc -cpu host"
     },
     "images": [
         {


### PR DESCRIPTION
Execution log:
qemu-system-x86_64: unsupported machine type
Use -machine help to list supported machines

after qemu upgrade to 6.2.0, some errors occured