### PR TITLE
Adding Windows-11-Dev-Env - 2308

### DIFF
--- a/appliances/windows-11-dev-env.gns3a
+++ b/appliances/windows-11-dev-env.gns3a
@@ -30,6 +30,14 @@
     },
     "images": [
         {
+            "filename": "WinDev2308Eval-disk1.vmdk",
+            "version": "2308",
+            "md5sum": "6a9b4ed6d7481f7bbf8a054c797b1eee",
+            "filesize": 24697637344,
+            "download_url": "https://download.microsoft.com/download/7/1/3/7135f2ab-8528-49fc-9252-8d5d94c697ef/WinDev2308Eval.VMWare.zip",
+            "compression": "zip"
+        },
+        {
             "filename": "WinDev2212Eval-disk1.vmdk",
             "version": "2212",
             "md5sum": "c79f393a067b92e01a513a118d455ac8",
@@ -48,6 +56,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "2308",
+            "images": {
+                "bios_image": "OVMF-edk2-stable202305.fd",
+                "hda_disk_image": "WinDev2308Eval-disk1.vmdk"
+            }
+        },
         {
             "name": "2212",
             "images": {


### PR DESCRIPTION
Adding Windows-11-Dev-Env - 2308

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---