### PR TITLE
correcting the filezise of the "WinDev2308Eval-disk1.vmdk"

### DIFF
--- a/appliances/windows-11-dev-env.gns3a
+++ b/appliances/windows-11-dev-env.gns3a
@@ -33,7 +33,7 @@
             "filename": "WinDev2308Eval-disk1.vmdk",
             "version": "2308",
             "md5sum": "6a9b4ed6d7481f7bbf8a054c797b1eee",
-            "filesize": 24697637344,
+            "filesize": 24945341952,
             "download_url": "https://download.microsoft.com/download/7/1/3/7135f2ab-8528-49fc-9252-8d5d94c697ef/WinDev2308Eval.VMWare.zip",
             "compression": "zip"
         },


### PR DESCRIPTION
correcting the filezise of the "WinDev2308Eval-disk1.vmdk" from my PR GNS3#811

I had an incorrect `filesize` reference in my previous PR, the `md5sum` is correct, just the `filesize` was wrong.
Sorry for the inconvenience

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.

