### PR TITLE
vyos - direct download from s3-us.vyos.io no longer working

### DIFF
--- a/appliances/vyos.gns3a
+++ b/appliances/vyos.gns3a
@@ -59,32 +59,28 @@
             "version": "1.2.9-S1",
             "md5sum": "3fece6363f9766f862e26d292d0ed5a3",
             "filesize": 430964736,
-            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-s1-generic-iso-image",
-            "direct_download_url": "https://s3-us.vyos.io/1.2.9-S1/vyos-1.2.9-S1-amd64.iso"
+            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-s1-generic-iso-image"
         },
         {
             "filename": "vyos-1.2.9-S1-10G-qemu.qcow2",
             "version": "1.2.9-S1-KVM",
             "md5sum": "0a70d78b80a3716d42487c02ef44f41f",
             "filesize": 426967040,
-            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-s1-for-kvm",
-            "direct_download_url": "https://s3-us.vyos.io/1.2.9-S1/vyos-1.2.9-S1-10G-qemu.qcow2"
+            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-s1-for-kvm"
         },
         {
             "filename": "vyos-1.2.9-amd64.iso",
             "version": "1.2.9",
             "md5sum": "586be23b6256173e174c82d8f1f699a1",
             "filesize": 430964736,
-            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-generic-iso-image",
-            "direct_download_url": "https://s3-us.vyos.io/1.2.9/vyos-1.2.9-amd64.iso"
+            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-generic-iso-image"
         },
         {
             "filename": "vyos-1.2.9-10G-qemu.qcow2",
             "version": "1.2.9-KVM",
             "md5sum": "76871c7b248c32f75177c419128257ac",
             "filesize": 427360256,
-            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-10g-qemu-qcow2",
-            "direct_download_url": "https://s3-us.vyos.io/1.2.9/vyos-1.2.9-10G-qemu.qcow2"
+            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-10g-qemu-qcow2"
         },
         {
             "filename": "vyos-1.2.8-amd64.iso",
@@ -92,13 +88,6 @@
             "md5sum": "0ad879db903efdbf1c39dc945e165931",
             "filesize": 429916160,
             "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-8-generic-iso-image"
-        },
-        {
-            "filename": "vyos-1.1.8-amd64.iso",
-            "version": "1.1.8",
-            "md5sum": "95a141d4b592b81c803cdf7e9b11d8ea",
-            "filesize": 241172480,
-            "direct_download_url": "https://s3-us.vyos.io/vyos-1.1.8-amd64.iso"
         },
         {
             "filename": "empty8G.qcow2",
@@ -169,13 +158,6 @@
             "images": {
                 "hda_disk_image": "empty8G.qcow2",
                 "cdrom_image": "vyos-1.2.8-amd64.iso"
-            }
-        },
-        {
-            "name": "1.1.8",
-            "images": {
-                "hda_disk_image": "empty8G.qcow2",
-                "cdrom_image": "vyos-1.1.8-amd64.iso"
             }
         }
     ]


### PR DESCRIPTION
As direct downloads from s3-us.vyos.io are no longer working, the corresponding `direct_download_url` entries have to go. The (very old) version 1.1.8 was only available via direct download, so this version is no longer available.

---

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
