### PR TITLE
RedHat 9 based appliances - add option "-cpu host"

### DIFF
--- a/appliances/almalinux.gns3a
+++ b/appliances/almalinux.gns3a
@@ -21,7 +21,8 @@
         "hda_disk_interface": "sata",
         "arch": "x86_64",
         "console_type": "telnet",
-        "kvm": "allow"
+        "kvm": "allow",
+        "options": "-cpu host -nographic"
     },
     "images": [
         {

--- a/appliances/centos-cloud.gns3a
+++ b/appliances/centos-cloud.gns3a
@@ -12,7 +12,7 @@
     "status": "stable",
     "maintainer": "GNS3 Team",
     "maintainer_email": "developers@gns3.net",
-    "usage": "Username: centos\nPassword: centos",
+    "usage": "Username: centos or cloud-user\nPassword: centos",
     "port_name_format": "Ethernet{0}",
     "qemu": {
         "adapter_type": "virtio-net-pci",
@@ -23,16 +23,16 @@
         "console_type": "telnet",
         "boot_priority": "c",
         "kvm": "require",
-        "options": "-nographic"
+        "options": "-cpu host -nographic"
     },
     "images": [
         {
-            "filename": "CentOS-Stream-GenericCloud-9-20230727.1.x86_64.qcow2",
-            "version": "Stream-9 (20230727.1)",
-            "md5sum": "b66b7e4951cb5491ae44d5616d56b7cf",
-            "filesize": 1128764416,
+            "filename": "CentOS-Stream-GenericCloud-9-20230704.1.x86_64.qcow2",
+            "version": "Stream-9 (20230704.1)",
+            "md5sum": "e04511e019325a97837edd9eafe02b48",
+            "filesize": 1087868416,
             "download_url": "https://cloud.centos.org/centos/9-stream/x86_64/images",
-            "direct_download_url": "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230727.1.x86_64.qcow2"
+            "direct_download_url": "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230704.1.x86_64.qcow2"
         },
         {
             "filename": "CentOS-Stream-GenericCloud-8-20230710.0.x86_64.qcow2",
@@ -77,9 +77,9 @@
     ],
     "versions": [
         {
-            "name": "Stream-9 (20230727.1)",
+            "name": "Stream-9 (20230704.1)",
             "images": {
-                "hda_disk_image": "CentOS-Stream-GenericCloud-9-20230727.1.x86_64.qcow2",
+                "hda_disk_image": "CentOS-Stream-GenericCloud-9-20230704.1.x86_64.qcow2",
                 "cdrom_image": "centos-cloud-init-data.iso"
             }
         },

--- a/appliances/rhel.gns3a
+++ b/appliances/rhel.gns3a
@@ -23,7 +23,7 @@
         "console_type": "telnet",
         "boot_priority": "c",
         "kvm": "require",
-        "options": "-nographic"
+        "options": "-cpu host -nographic"
     },
     "images": [
         {


### PR DESCRIPTION
Fixed issue #818, add option "-cpu host" to RedHat 9 based appliances.

Replaced the Stream-9 image of the centos-cloud appliance to an image, that is available, updated the usage instruction.

@Da-Geek - While it's nice, that you update appliances, please check that your updates are working.

---

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
