### PR TITLE
vyos - download of legacy releases from legacy-lts-images.vyos.io

### DIFF
--- a/appliances/vyos.gns3a
+++ b/appliances/vyos.gns3a
@@ -59,28 +59,32 @@
             "version": "1.2.9-S1",
             "md5sum": "3fece6363f9766f862e26d292d0ed5a3",
             "filesize": 430964736,
-            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-s1-generic-iso-image"
+            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-s1-generic-iso-image",
+            "direct_download_url": "https://legacy-lts-images.vyos.io/1.2.9-S1/vyos-1.2.9-S1-amd64.iso"
         },
         {
             "filename": "vyos-1.2.9-S1-10G-qemu.qcow2",
             "version": "1.2.9-S1-KVM",
             "md5sum": "0a70d78b80a3716d42487c02ef44f41f",
             "filesize": 426967040,
-            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-s1-for-kvm"
+            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-s1-for-kvm",
+            "direct_download_url": "https://legacy-lts-images.vyos.io/1.2.9-S1/vyos-1.2.9-S1-10G-qemu.qcow2"
         },
         {
             "filename": "vyos-1.2.9-amd64.iso",
             "version": "1.2.9",
             "md5sum": "586be23b6256173e174c82d8f1f699a1",
             "filesize": 430964736,
-            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-generic-iso-image"
+            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-generic-iso-image",
+            "direct_download_url": "https://legacy-lts-images.vyos.io/1.2.9/vyos-1.2.9-amd64.iso"
         },
         {
             "filename": "vyos-1.2.9-10G-qemu.qcow2",
             "version": "1.2.9-KVM",
             "md5sum": "76871c7b248c32f75177c419128257ac",
             "filesize": 427360256,
-            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-10g-qemu-qcow2"
+            "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-9-10g-qemu-qcow2",
+            "direct_download_url": "https://legacy-lts-images.vyos.io/1.2.9/vyos-1.2.9-10G-qemu.qcow2"
         },
         {
             "filename": "vyos-1.2.8-amd64.iso",
@@ -88,6 +92,13 @@
             "md5sum": "0ad879db903efdbf1c39dc945e165931",
             "filesize": 429916160,
             "download_url": "https://support.vyos.io/en/downloads/files/vyos-1-2-8-generic-iso-image"
+        },
+        {
+            "filename": "vyos-1.1.8-amd64.iso",
+            "version": "1.1.8",
+            "md5sum": "95a141d4b592b81c803cdf7e9b11d8ea",
+            "filesize": 241172480,
+            "direct_download_url": "https://legacy-lts-images.vyos.io/vyos-1.1.8-amd64.iso"
         },
         {
             "filename": "empty8G.qcow2",
@@ -158,6 +169,13 @@
             "images": {
                 "hda_disk_image": "empty8G.qcow2",
                 "cdrom_image": "vyos-1.2.8-amd64.iso"
+            }
+        },
+        {
+            "name": "1.1.8",
+            "images": {
+                "hda_disk_image": "empty8G.qcow2",
+                "cdrom_image": "vyos-1.1.8-amd64.iso"
             }
         }
     ]


### PR DESCRIPTION
Because the download links to the legacy releases on <https://vyos.net/get/> were no longer working, I removed them in PR #815. Today I stumbled across another download location on <https://support.vyos.io/en/support/solutions/articles/103000099217-vyos-1-2-9-s1>, that actually works. So I am able to re-add the direct download locations of the legacy releases.

---

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
