### PR TITLE
Updating Oracle Linux 7.9, 8.8, & 9.2

### DIFF
--- a/appliances/oracle-linux-cloud.gns3a
+++ b/appliances/oracle-linux-cloud.gns3a
@@ -27,6 +27,14 @@
     },
     "images": [
         {
+            "filename": "OL9U2_x86_64-kvm-b197.qcow",
+            "version": "9.2",
+            "md5sum": "2ff3d0bc8a243ad89c96215f303f1c73",
+            "filesize": 560791552,
+            "download_url": "https://yum.oracle.com/oracle-linux-templates.html",
+            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL9/u2/x86_64/OL9U2_x86_64-kvm-b197.qcow"
+        },
+        {
             "filename": "OL9U1_x86_64-kvm-b158.qcow",
             "version": "9.1",
             "md5sum": "9f32851b96fc38191892197fa11f7435",
@@ -35,12 +43,28 @@
             "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL9/u1/x86_64/OL9U1_x86_64-kvm-b158.qcow"
         },
         {
+            "filename": "OL8U8_x86_64-kvm-b198.qcow",
+            "version": "8.8",
+            "md5sum": "717622f373d77349cc102a3a325efbd3",
+            "filesize": 934215680,
+            "download_url": "https://yum.oracle.com/oracle-linux-templates.html",
+            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL8/u8/x86_64/OL8U8_x86_64-kvm-b198.qcow"
+        },
+        {
             "filename": "OL8U7_x86_64-kvm-b148.qcow",
             "version": "8.7",
             "md5sum": "962cdde7e810888b9914e937222f687f",
             "filesize": 913965056,
             "download_url": "https://yum.oracle.com/oracle-linux-templates.html",
             "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL8/u7/x86_64/OL8U7_x86_64-kvm-b148.qcow"
+        },
+        {
+            "filename": "OL7U9_x86_64-kvm-b145.qcow",
+            "version": "7.9",
+            "md5sum": "e60d4145a69b34026db6121109ca9131",
+            "filesize": 725221376,
+            "download_url": "https://yum.oracle.com/oracle-linux-templates.html",
+            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL7/u9/x86_64/OL7U9_x86_64-kvm-b145.qcow"
         },
         {
             "filename": "oracle-cloud-init-data.iso",
@@ -52,6 +76,13 @@
         }
     ],
     "versions": [
+{
+            "name": "9.2",
+            "images": {
+                "hda_disk_image": "OL9U2_x86_64-kvm-b197.qcow",
+                "cdrom_image": "oracle-cloud-init-data.iso"
+            }
+        },
         {
             "name": "9.1",
             "images": {
@@ -60,9 +91,23 @@
             }
         },
         {
+            "name": "8.8",
+            "images": {
+                "hda_disk_image": "OL8U8_x86_64-kvm-b198.qcow",
+                "cdrom_image": "oracle-cloud-init-data.iso"
+            }
+        },
+        {
             "name": "8.7",
             "images": {
                 "hda_disk_image": "OL8U7_x86_64-kvm-b148.qcow",
+                "cdrom_image": "oracle-cloud-init-data.iso"
+            }
+        },
+        {
+            "name": "7.9",
+            "images": {
+                "hda_disk_image": "OL7U9_x86_64-kvm-b145.qcow",
                 "cdrom_image": "oracle-cloud-init-data.iso"
             }
         }


### PR DESCRIPTION
Updating Oracle Linux 7.9, 8.8, & 9.2

![Screenshot 2023-09-30 19 05 04](https://github.com/GNS3/gns3-registry/assets/6429103/b938a83e-2bb4-4268-a871-bddd9322de01)
![Screenshot 2023-09-30 19 05 00](https://github.com/GNS3/gns3-registry/assets/6429103/d4304903-088c-441c-a21e-16733bf6746f)
![Screenshot 2023-09-30 19 05 09](https://github.com/GNS3/gns3-registry/assets/6429103/d0eb80dc-67e5-49d9-9433-65fbade9e142)

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
