### PR TITLE
Adding OpenWrt 23.05.0

### DIFF
--- a/appliances/openwrt.gns3a
+++ b/appliances/openwrt.gns3a
@@ -24,6 +24,15 @@
     },
     "images": [
         {
+            "filename": "openwrt-23.05.0-x86-64-generic-ext4-combined.img",
+            "version": "23.05.0",
+            "md5sum": "8d53c7aa2605a8848b0b2ca759fc924f",
+            "filesize": 126353408,
+            "download_url": "https://downloads.openwrt.org/releases/23.05.0/targets/x86/64/",
+            "direct_download_url": "https://downloads.openwrt.org/releases/23.05.0/targets/x86/64/openwrt-23.05.0-x86-64-generic-ext4-combined.img.gz",
+            "compression": "gzip"
+        },
+        {
             "filename": "openwrt-22.03.0-x86-64-generic-ext4-combined.img",
             "version": "22.03.0",
             "md5sum": "0f9a266bd8a6cdfcaf0b59f7ba103a0e",
@@ -214,6 +223,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "23.05.0",
+            "images": {
+                "hda_disk_image": "openwrt-23.05.0-x86-64-generic-ext4-combined.img"
+            }
+        },
         {
             "name": "22.03.0",
             "images": {


### PR DESCRIPTION
Adding OpenWrt v23.05.0

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
![Screenshot 2023-10-17 18 14 15](https://github.com/GNS3/gns3-registry/assets/6429103/94cd7ae1-07ed-4a1a-baf6-ffda3eab77b2)
