### PR TITLE
Correcting an md5sum conflict in `empty-vm.gns3a` noticed running check.py for PR #831

### DIFF
--- a/appliances/empty-vm.gns3a
+++ b/appliances/empty-vm.gns3a
@@ -84,7 +84,7 @@
         {
             "filename": "empty150G.qcow2",
             "version": "150G",
-            "md5sum": "4a9e538aa1946a27d91a8d53a8dbc546",
+            "md5sum": "7db590ad39f84fdfc91516d162af26f6",
             "filesize": 199008,
             "download_url": "https://sourceforge.net/projects/gns-3/files/Empty%20Qemu%20disk/",
             "direct_download_url": "https://sourceforge.net/projects/gns-3/files/Empty%20Qemu%20disk/empty150G.qcow2/download"


### PR DESCRIPTION
Correcting an md5sum conflict in `empty-vm.gns3a` noticed running check.py for PR #831

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
