### PR TITLE
Adding CHR v7.11.2 & v6.49.10

### DIFF
--- a/appliances/mikrotik-chr.gns3a
+++ b/appliances/mikrotik-chr.gns3a
@@ -28,6 +28,15 @@
     },
     "images": [
         {
+            "filename": "chr-7.11.2.img",
+            "version": "7.11.2",
+            "md5sum": "fbffd097d2c5df41fc3335c3977f782c",
+            "filesize": 134217728,
+            "download_url": "http://www.mikrotik.com/download",
+            "direct_download_url": "https://download.mikrotik.com/routeros/7.11.2/chr-7.11.2.img.zip",
+            "compression": "zip"
+        },
+        {
             "filename": "chr-7.10.1.img",
             "version": "7.10.1",
             "md5sum": "917729e79b9992562f4160d461b21cac",
@@ -73,6 +82,15 @@
             "compression": "zip"
         },
         {
+            "filename": "chr-6.49.10.img",
+            "version": "6.49.10",
+            "md5sum": "49ae1ecfe310aea1df37b824aa13cf84",
+            "filesize": 67108864,
+            "download_url": "http://www.mikrotik.com/download",
+            "direct_download_url": "https://download.mikrotik.com/routeros/6.49.10/chr-6.49.10.img.zip",
+            "compression": "zip"
+        },
+        {
             "filename": "chr-6.49.6.img",
             "version": "6.49.6",
             "md5sum": "ae27d38acc9c4dcd875e0f97bcae8d97",
@@ -92,6 +110,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "7.11.2",
+            "images": {
+                "hda_disk_image": "chr-7.11.2.img"
+            }
+        },
         {
             "name": "7.10.1",
             "images": {
@@ -120,6 +144,12 @@
             "name": "7.1.5",
             "images": {
                 "hda_disk_image": "chr-7.1.5.img"
+            }
+        },
+        {
+            "name": "6.49.10",
+            "images": {
+                "hda_disk_image": "chr-6.49.10.img"
             }
         },
         {


### PR DESCRIPTION

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.

![Screenshot 2023-10-17 20 34 20](https://github.com/GNS3/gns3-registry/assets/6429103/9c549d38-7fba-4551-b3a2-af9f9f501cef)
![Screenshot 2023-10-17 20 34 23](https://github.com/GNS3/gns3-registry/assets/6429103/5dfea553-0163-4f4e-a1e7-e156341d1f9c)
