### PR TITLE
Docker build: Simplify definition of DOCKER_REPOSITORY

### DIFF
--- a/.github/bin/docker_build
+++ b/.github/bin/docker_build
@@ -345,7 +345,7 @@ def needs_rebuild(image, default_repository=None):
     if base_name not in image_info:
         image_info[base_name] = get_time_layers(base_name)
     if not image_info[base_name]:
-        sys.exit(f"Missing base image: {base_name}")
+        sys.exit(f"{image['name']}: Missing base image: {base_name}")
 
     # get information of image, if unknown
     if full_name not in image_info:

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -63,13 +63,11 @@ jobs:
       - name: Build and push images
         env:
           # DOCKER_REPOSITORY - Repository for name-only images
-          # DockerHub:
-          #DOCKER_REPOSITORY: ${{ secrets.DOCKERHUB_REPOSITORY }}
-          # GitHub Container Registry:
-          #DOCKER_REPOSITORY: ghcr.io/${{ github.repository_owner }}
-          # Both DockerHub and GitHub Container Registry:
-          DOCKER_REPOSITORY: >-
+          # Using multiple repositories will build images in all of them.
+          DOCKER_REPOSITORY: |
+            # DockerHub:
             ${{ secrets.DOCKERHUB_REPOSITORY }}
+            # GitHub Container Registry:
             ghcr.io/${{ github.repository_owner }}
           #
           # Variables whose name are starting with "DOCKER_LOGIN"
@@ -90,6 +88,7 @@ jobs:
           #
           IMAGES: ${{ inputs.images }}
         run: |
+          DOCKER_REPOSITORY=$(echo "$DOCKER_REPOSITORY" | sed '/^#/d')
           set -f
           set -- $IMAGES
           set +f


### PR DESCRIPTION
The definition of DOCKER_REPOSITORY in the Docker workflow is quite complex as YAML doesn't allow comments inside scalars, as they can't be distinguished from data.

This PR allows comments in the DOCKER_REPOSITORY definition. They are filtered out in the first statement of the `run` script.