### PR TITLE
ostinato-wireshark: No need to use edge repository since alpine 3.19

### DIFF
--- a/docker/ostinato-wireshark/Dockerfile
+++ b/docker/ostinato-wireshark/Dockerfile
@@ -6,10 +6,7 @@ ENV DISPLAY :99
 ENV RESOLUTION 1920x1080x24
 
 
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
-    && echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
-    && echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
-    && apk add --no-cache \
+RUN apk add --no-cache \
 	libprotobuf \
 	tshark \
 	wireshark \


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
