### PR TITLE
Updated Cisco appliance versions for CML 2.6

### DIFF
--- a/appliances/cisco-asav.gns3a
+++ b/appliances/cisco-asav.gns3a
@@ -27,6 +27,13 @@
     },
     "images": [
         {
+            "filename": "asav9-18-2.qcow2",
+            "version": "9.18.2 CML",
+            "md5sum": "6f10fe106edfad9163625770a47a6b73",
+            "filesize": 340262912,
+            "download_url": "https://learningnetworkstore.cisco.com/cisco-modeling-labs-personal/cisco-modeling-labs-personal/CML-PERSONAL.html"
+        },
+        {
             "filename": "asav9-16-2.qcow2",
             "version": "9.16.2 CML",
             "md5sum": "1f8db97063a7f738fddc81ac880a906c",
@@ -119,6 +126,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "9.18.2 CML",
+            "images": {
+                "hda_disk_image": "asav9-18-2.qcow2"
+            }
+        },
         {
             "name": "9.16.2 CML",
             "images": {

--- a/appliances/cisco-c8000v.gns3a
+++ b/appliances/cisco-c8000v.gns3a
@@ -25,6 +25,13 @@
     },
     "images": [
         {
+            "filename": "c8000v-universalk9_8G_serial.17.09.01a.qcow2",
+            "version": "17.09.01a 8G",
+            "md5sum": "a10ae2c4d71f4eb611bc4d83ad7709f0",
+            "filesize": 1856634880,
+            "download_url": "https://software.cisco.com/download/home/286327102/type/282046477/release/Bengaluru-17.6.5"
+        },
+        {
             "filename": "c8000v-universalk9_8G_serial.17.06.05.qcow2",
             "version": "17.06.05 8G",
             "md5sum": "aeb15ab8e1cbd0cd76f7260a81442f98",
@@ -54,6 +61,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "17.09.01a 8G",
+            "images": {
+                "hda_disk_image": "c8000v-universalk9_8G_serial.17.09.01a.qcow2"
+            }
+        },
         {
             "name": "17.06.05 8G",
             "images": {

--- a/appliances/cisco-csr1000v.gns3a
+++ b/appliances/cisco-csr1000v.gns3a
@@ -25,6 +25,13 @@
     },
     "images": [
         {
+            "filename": "csr1000v-universalk9.17.03.06-serial.qcow2",
+            "version": "17.03.06",
+            "md5sum": "086ab9bef6e66de847af0da3910c60e8",
+            "filesize": 1422000128,
+            "download_url": "https://software.cisco.com/download/home/284364978/type/282046477/release/Gibraltar-16.12.3"
+        },
+        {
             "filename": "csr1000v-universalk9.16.12.03-serial.qcow2",
             "version": "16.12.3",
             "md5sum": "1fc380569ad3cc145fb9cbc993b2eb32",
@@ -159,6 +166,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "17.03.06",
+            "images": {
+                "hda_disk_image": "csr1000v-universalk9.17.03.06-serial.qcow2"
+            }
+        },
         {
             "name": "16.12.3",
             "images": {

--- a/appliances/cisco-iosxrv9k.gns3a
+++ b/appliances/cisco-iosxrv9k.gns3a
@@ -27,6 +27,13 @@
     },
     "images": [
         {
+            "filename": "xrv9k-fullk9-x-7.7.1.qcow2",
+            "version": "7.7.1",
+            "md5sum": "682fff40d2ff373d8da3342906553b54",
+            "filesize": 1643905024,
+            "download_url": "https://software.cisco.com/download/home/286288939/type/280805694/release/7.1.1"
+        },
+        {
             "filename": "xrv9k-fullk9-x-7.1.1.qcow2",
             "version": "7.1.1",
             "md5sum": "dcf241e3f8df0151fec2c7bfac9d96ac",
@@ -105,6 +112,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "7.7.1",
+            "images": {
+                "hda_disk_image": "xrv9k-fullk9-x-7.7.1.qcow2"
+            }
+        },
         {
             "name": "7.1.1",
             "images": {

--- a/appliances/cisco-nxosv9k.gns3a
+++ b/appliances/cisco-nxosv9k.gns3a
@@ -27,6 +27,13 @@
     },
     "images": [
         {
+            "filename": "nexus9300v64.10.3.1.F.qcow2",
+            "version": "9300v 10.3.1.F",
+            "md5sum": "a6ffd2501a5791c11cee319943b912da",
+            "filesize": 2097086464,
+            "download_url": "https://software.cisco.com/download/home/286312239/type/282088129/release/10.1(1)"
+        },
+        {
             "filename": "nexus9500v64.10.1.1.qcow2",
             "version": "9500v 10.1.1",
             "md5sum": "35672370b0f43e725d5b2d92488524f0",
@@ -198,6 +205,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "9300v 10.3.1.F",
+            "images": {
+                "bios_image": "OVMF-edk2-stable202305.fd",
+                "hda_disk_image": "nexus9300v64.10.3.1.F.qcow2"
+            }
+        },
         {
             "name": "9500v 10.1.1",
             "images": {


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
-- Long standing version mismatch error reported by check.py on asav.gns3a for version 9.16.2 CML (irrelevant to this PR as it add 9.18.2.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
