### PR TITLE
Debian: Update to version 12.4

### DIFF
--- a/appliances/debian.gns3a
+++ b/appliances/debian.gns3a
@@ -24,12 +24,12 @@
     },
     "images": [
         {
-            "filename": "debian-12.2.qcow2",
-            "version": "12.2",
-            "md5sum": "adf7716ec4a4e4e9e5ccfc7a1d7bd103",
-            "filesize": 286654464,
+            "filename": "debian-12.4.qcow2",
+            "version": "12.4",
+            "md5sum": "adcf7fdc25e10b3d2d9e2ef91168bffd",
+            "filesize": 286179840,
             "download_url": "https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/",
-            "direct_download_url": "https://downloads.sourceforge.net/project/gns-3/Qemu%20Appliances/debian-12.2.qcow2"
+            "direct_download_url": "https://downloads.sourceforge.net/project/gns-3/Qemu%20Appliances/debian-12.4.qcow2"
         },
         {
             "filename": "debian-11.8.qcow2",
@@ -42,9 +42,9 @@
     ],
     "versions": [
         {
-            "name": "12.2",
+            "name": "12.4",
             "images": {
-                "hda_disk_image": "debian-12.2.qcow2"
+                "hda_disk_image": "debian-12.4.qcow2"
             }
         },
         {

--- a/packer/debian/debian.json
+++ b/packer/debian/debian.json
@@ -1,7 +1,7 @@
 {
     "variables": {
-        "iso_url": "https://cloud.debian.org/images/cloud/bookworm/20231013-1532/debian-12-genericcloud-amd64-20231013-1532.qcow2",
-        "iso_checksum": "3a5fd3f38f055ceb1a2f84c6184ca4de3566e29e519b405865719cc43426afdf",
+        "iso_url": "https://cloud.debian.org/images/cloud/bookworm/20231210-1591/debian-12-genericcloud-amd64-20231210-1591.qcow2",
+        "iso_checksum": "16e360b50572092ff5c1ed994285bcca961df28c081b7bb5d7c006d35bce4914",
         "disk_size": "2G",
         "vm_name": "debian.qcow2",
         "setup_script": "debian.sh"


### PR DESCRIPTION
Update Debian to version 12.4

@grossmj
As the image is created by packer, it has to be build and then uploaded to <https://downloads.sourceforge.net/project/gns-3/Qemu%20Appliances/debian-12.4.qcow2>. If you build the image yourself, the size and md5sum in the appliance has to be adapted. If you like to use my build, you can get it from <https://github.com/b-ehlers/gns3-registry/releases/download/debian-12.4/debian-12.4.qcow2>.

Debian tells us:
> Please note that the point release does not constitute a new version of Debian 12 but only updates some of the packages included. 

Therefore this version 12.4 replaces 12.2. The old debian-12.2.qcow2 can be deleted when the updated appliance has reached (almost) all of the GNS3 installations, perhaps in a few months.

---

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
