### PR TITLE
Add Ostinato version 1.3.0

### DIFF
--- a/appliances/ostinato.gns3a
+++ b/appliances/ostinato.gns3a
@@ -31,6 +31,13 @@
     },
     "images": [
         {
+            "version": "1.3.0",
+            "filename": "ostinatostd-1.3.0-1.qcow2",
+            "filesize": 173735936,
+            "md5sum": "ff25fed989c43aeac84bf0d542ad43ba",
+            "download_url": "https://ostinato.org/pricing/gns3"
+        },
+        {
             "filename": "ostinatostd-1.2.0-1.qcow2",
             "version": "1.2.0",
             "md5sum": "682680fe75f88975992c0a1a5c973149",
@@ -46,6 +53,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "1.3.0",
+            "images": {
+                "hda_disk_image": "ostinatostd-1.3.0-1.qcow2"
+            }
+        },
         {
             "name": "1.2.0",
             "images": {


### PR DESCRIPTION
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ ] If you forked the repo, running check.py doesn't drop any errors for the updated file.

Unable to install `pycurl==7.44.1` (required by `check.py`) on both Windows 10 and Ubuntu 22.04
