### PR TITLE
Adding Fedora Cloud 39, and removing EOL 35, 36, & 37

### DIFF
--- a/appliances/fedora-cloud.gns3a
+++ b/appliances/fedora-cloud.gns3a
@@ -27,6 +27,14 @@
     },
     "images": [
         {
+            "filename": "Fedora-Cloud-Base-39-1.5.x86_64.qcow2",
+            "version": "39-1.5",
+            "md5sum": "800a10df2d369891ed65900bcacacd47",
+            "filesize": 544604160,
+            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images",
+            "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2"
+        },
+        {
             "filename": "Fedora-Cloud-Base-38-1.6.x86_64.qcow2",
             "version": "38-1.6",
             "md5sum": "53ddfe7b28666d5ddc55e93ff06abad2",
@@ -68,6 +76,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "39-1.5",
+            "images": {
+                "hda_disk_image": "Fedora-Cloud-Base-39-1.5.x86_64.qcow2",
+                "cdrom_image": "fedora-cloud-init-data.iso"
+            }
+        },
         {
             "name": "38-1.6",
             "images": {

--- a/appliances/fedora-cloud.gns3a
+++ b/appliances/fedora-cloud.gns3a
@@ -43,30 +43,6 @@
             "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
         },
         {
-            "filename": "Fedora-Cloud-Base-37-1.7.x86_64.qcow2",
-            "version": "37-1.7",
-            "md5sum": "36f7b464b6ab46ad97c001b539495e90",
-            "filesize": 492830720,
-            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images",
-            "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images/Fedora-Cloud-Base-37-1.7.x86_64.qcow2"
-        },
-        {
-            "filename": "Fedora-Cloud-Base-36-1.5.x86_64.qcow2",
-            "version": "36-1.5",
-            "md5sum": "7f7cdad25b77f232078bf454c39529d3",
-            "filesize": 448266240,
-            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images",
-            "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2"
-        },
-        {
-            "filename": "Fedora-Cloud-Base-35-1.2.x86_64.qcow2",
-            "version": "35-1.2",
-            "md5sum": "cfa9cdcfb946e5f4cf9dd4d7906008d0",
-            "filesize": 376897536,
-            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images",
-            "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2"
-        },
-        {
             "filename": "fedora-cloud-init-data.iso",
             "version": "1.0",
             "md5sum": "3d0d6391d3f5ece1180c70b9667c4dca",
@@ -87,27 +63,6 @@
             "name": "38-1.6",
             "images": {
                 "hda_disk_image": "Fedora-Cloud-Base-38-1.6.x86_64.qcow2",
-                "cdrom_image": "fedora-cloud-init-data.iso"
-            }
-        },
-        {
-            "name": "37-1.7",
-            "images": {
-                "hda_disk_image": "Fedora-Cloud-Base-37-1.7.x86_64.qcow2",
-                "cdrom_image": "fedora-cloud-init-data.iso"
-            }
-        },
-        {
-            "name": "36-1.5",
-            "images": {
-                "hda_disk_image": "Fedora-Cloud-Base-36-1.5.x86_64.qcow2",
-                "cdrom_image": "fedora-cloud-init-data.iso"
-            }
-        },
-        {
-            "name": "35-1.2",
-            "images": {
-                "hda_disk_image": "Fedora-Cloud-Base-35-1.2.x86_64.qcow2",
                 "cdrom_image": "fedora-cloud-init-data.iso"
             }
         }


### PR DESCRIPTION
---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.

![Screenshot 2023-12-27 18 48 23](https://github.com/GNS3/gns3-registry/assets/6429103/732eff69-afef-4fd1-ba6d-96cddfa453ad)
