### PR TITLE
Adding Red Hat Enterprise Linux 9.3 KVM Guest Image

### DIFF
--- a/appliances/rhel.gns3a
+++ b/appliances/rhel.gns3a
@@ -11,9 +11,9 @@
     "registry_version": 4,
     "status": "stable",
     "availability": "service-contract",
-    "maintainer": "Neyder Achahuanco",
-    "maintainer_email": "neyder@neyder.net",
-    "usage": "You should download Red Hat Enterprise Linux KVM Guest Image from https://access.redhat.com/downloads/content/479/ver=/rhel---9/9.2/x86_64/product-software attach/customize cloud-init.iso and start.\nusername: cloud-user\npassword: redhat",
+    "maintainer": "Da-Geek",
+    "maintainer_email": "dageek@dageeks-geeks.gg",
+    "usage": "You should download Red Hat Enterprise Linux KVM Guest Image from https://access.redhat.com/downloads/content/479/ver=/rhel---9/9.3/x86_64/product-software attach/customize rhel-cloud-init.iso and start.\nusername: cloud-user\npassword: redhat",
     "qemu": {
         "adapter_type": "virtio-net-pci",
         "adapters": 1,
@@ -26,6 +26,13 @@
         "options": "-cpu host -nographic"
     },
     "images": [
+        {
+            "filename": "rhel-9.3-x86_64-kvm.qcow2",
+            "version": "9.3",
+            "md5sum": "409d8d15f5177db2617b0e3e02139b5c",
+            "filesize": 858193920,
+            "download_url": "https://access.redhat.com/downloads/content/479/ver=/rhel---9/9.3/x86_64/product-software"
+        },
         {
             "filename": "rhel-9.2-x86_64-kvm.qcow2",
             "version": "9.2",
@@ -112,6 +119,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "9.3",
+            "images": {
+                "hda_disk_image": "rhel-9.3-x86_64-kvm.qcow2",
+                "cdrom_image": "rhel-cloud-init.iso"
+            }
+        },
         {
             "name": "9.2",
             "images": {


### PR DESCRIPTION
---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.

![Screenshot 2023-12-27 20 02 58](https://github.com/GNS3/gns3-registry/assets/6429103/f49f8720-e477-40cc-8e03-c4acc7a59ba1)
