### PR TITLE
Adding Rocky GenericCloud-Base 8.9 & 9.3

### DIFF
--- a/appliances/rockylinux.gns3a
+++ b/appliances/rockylinux.gns3a
@@ -27,12 +27,28 @@
     },
     "images": [
         {
+            "filename": "Rocky-9-GenericCloud-Base-9.3-20231113.0.x86_64.qcow2",
+            "version": "9.3",
+            "md5sum": "48cdeb033364af5909e15ee48d0e144d",
+            "filesize": 1083965440,
+            "download_url": "https://download.rockylinux.org/pub/rocky/9/images/x86_64/",
+            "direct_download_url": "https://download.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base-9.3-20231113.0.x86_64.qcow2"
+        },
+        {
             "filename": "Rocky-9-GenericCloud-Base-9.2-20230513.0.x86_64.qcow2",
             "version": "9.2",
             "md5sum": "2022bdb49a691119f1fd3cc76de0a846",
             "filesize": 989265920,
             "download_url": "https://download.rockylinux.org/pub/rocky/9/images/x86_64/",
             "direct_download_url": "https://download.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base-9.2-20230513.0.x86_64.qcow2"
+        },
+        {
+            "filename": "Rocky-8-GenericCloud-Base-8.9-20231119.0.x86_64.qcow2",
+            "version": "8.9",
+            "md5sum": "50c44d8d9c4df43694372c13768f114c",
+            "filesize": 1971978240,
+            "download_url": "https://download.rockylinux.org/pub/rocky/8/images/x86_64/",
+            "direct_download_url": "https://download.rockylinux.org/pub/rocky/8/images/x86_64/Rocky-8-GenericCloud-Base-8.9-20231119.0.x86_64.qcow2"
         },
         {
             "filename": "Rocky-8-GenericCloud-Base-8.8-20230518.0.x86_64.qcow2",
@@ -53,9 +69,23 @@
     ],
     "versions": [
         {
+            "name": "9.3",
+            "images": {
+                "hda_disk_image": "Rocky-9-GenericCloud-Base-9.3-20231113.0.x86_64.qcow2",
+                "cdrom_image": "rocky-cloud-init-data.iso"
+            }
+        },
+        {
             "name": "9.2",
             "images": {
                 "hda_disk_image": "Rocky-9-GenericCloud-Base-9.2-20230513.0.x86_64.qcow2",
+                "cdrom_image": "rocky-cloud-init-data.iso"
+            }
+        },
+        {
+            "name": "8.9",
+            "images": {
+                "hda_disk_image": "Rocky-8-GenericCloud-Base-8.9-20231119.0.x86_64.qcow2",
                 "cdrom_image": "rocky-cloud-init-data.iso"
             }
         },


### PR DESCRIPTION
---
When updating an **existing** appliance:
- [X] The new version is on top.
        ** Version 9.3 is on top, but the new Version 8.9 is "in-line" between 8.8 & 9.2
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.

![Screenshot 2023-12-28 12 07 58](https://github.com/GNS3/gns3-registry/assets/6429103/787a1cda-a701-4cc7-a972-9e85b9c12600)
![Screenshot 2023-12-28 12 07 33](https://github.com/GNS3/gns3-registry/assets/6429103/43ae5c82-8d65-4f65-9f09-35427017a1aa)
