### PR TITLE
BIRD2: add version 2.14

### DIFF
--- a/appliances/bird2.gns3a
+++ b/appliances/bird2.gns3a
@@ -24,6 +24,14 @@
     },
     "images": [
         {
+            "filename": "bird2-debian-2.14.qcow2",
+            "version": "2.14",
+            "md5sum": "029cf1756201ee79497c169502b08b88",
+            "filesize": 303717376,
+            "download_url": "https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/",
+            "direct_download_url": "https://downloads.sourceforge.net/project/gns-3/Qemu%20Appliances/bird2-debian-2.14.qcow2"
+        },
+        {
             "filename": "bird2-debian-2.0.12.qcow2",
             "version": "2.0.12",
             "md5sum": "435218a2e90cba921cc7fde1d64a9419",
@@ -33,6 +41,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "2.14",
+            "images": {
+                "hda_disk_image": "bird2-debian-2.14.qcow2"
+            }
+        },
         {
             "name": "2.0.12",
             "images": {

--- a/packer/debian/bird2.json
+++ b/packer/debian/bird2.json
@@ -1,4 +1,6 @@
 {
     "vm_name": "bird2-debian.qcow2",
-    "setup_script": "bird2.sh"
+    "setup_script": "bird2.sh",
+    "iso_url": "https://cloud.debian.org/images/cloud/trixie/daily/20240118-1630/debian-13-genericcloud-amd64-daily-20240118-1630.qcow2",
+    "iso_checksum": "8e4919cee33a73000cd75e383f8954fb8a3234ee2f58cdfb5ea6adba55539cae"
 }

--- a/packer/debian/scripts/networking.sh
+++ b/packer/debian/scripts/networking.sh
@@ -12,7 +12,7 @@ fi
 cp /etc/resolv.conf /etc/resolv.conf.orig
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get upgrade
+apt-get -y upgrade
 apt-get -y install --purge ifupdown resolvconf
 cat /etc/resolv.conf.orig > /etc/resolv.conf
 rm -f /etc/resolv.conf.orig


### PR DESCRIPTION
Update of the BIRD2 appliance to v2.14.

I set the image location to <https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/bird2-debian-2.14.qcow2>.

As I can't upload to that location, I put it temporarily in <https://github.com/b-ehlers/gns3-registry/releases/download/bird2/bird2-debian-2.14.qcow2>, @grossmj please upload it to the final location.

---

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
