### PR TITLE
Docker build: Run push action only on changes within docker directory

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,10 +1,12 @@
-name: Build and upload Docker images
+name: Build Docker images
 
 on:
   push:
     branches:
       - main
       - master
+    paths:
+      - 'docker/**'
   schedule:
     - cron: '37 7 * * 3'
   workflow_dispatch:


### PR DESCRIPTION
This PR runs actions on git push / PR merges **only** when files in the `docker` directory have changed.

This will reduce the number of Action runs, as updating non-Docker appliances won't run the Docker build action.