### PR TITLE
Updates to various FortiProducts (ref #858) and check.py fixes

### DIFF
--- a/appliances/fortianalyzer.gns3a
+++ b/appliances/fortianalyzer.gns3a
@@ -30,6 +30,13 @@
     },
     "images": [
         {
+            "filename": "FAZ_VM64_KVM-v7.4.2-build2397-FORTINET.out.kvm.qcow2",
+            "version": "7.4.2",
+            "md5sum": "33b2938e19a6cb61d4d64e6998a54d23",
+            "filesize": 480096256,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FAZ_VM64_KVM-v7.4.1-build2308-FORTINET.out.kvm.qcow2",
             "version": "7.4.1",
             "md5sum": "f30caac36854c2a0cc1e35c4ab5f310d",
@@ -58,6 +65,13 @@
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
+            "filename": "FAZ_VM64_KVM-v7.0.11-build0595-FORTINET.out.kvm.qcow2",
+            "version": "7.0.11",
+            "md5sum": "ae7ff37d00d0b518e9982a0785665fc2",
+            "filesize": 349257728,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FAZ_VM64_KVM-v7.0.9-build0489-FORTINET.out.kvm.qcow2",
             "version": "7.0.9",
             "md5sum": "3f69c9bc4fa7776476edf0ce9728ebd7",
@@ -76,6 +90,13 @@
             "version": "7.0.5",
             "md5sum": "6cbc1f865ed285bb3a73323e222f03b8",
             "filesize": 334184448,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FAZ_VM64_KVM-v6.4.14-build2660-FORTINET.out.kvm.qcow2",
+            "version": "6.4.14",
+            "md5sum": "1629d76776c9d625faee0304b5840c02",
+            "filesize": 300683264,
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
@@ -236,6 +257,13 @@
     ],
     "versions": [
         {
+            "name": "7.4.2",
+            "images": {
+                "hda_disk_image": "FAZ_VM64_KVM-v7.4.2-build2397-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
             "name": "7.4.1",
             "images": {
                 "hda_disk_image": "FAZ_VM64_KVM-v7.4.1-build2308-FORTINET.out.kvm.qcow2",
@@ -264,6 +292,13 @@
             }
         },
         {
+            "name": "7.0.11",
+            "images": {
+                "hda_disk_image": "FAZ_VM64_KVM-v7.0.11-build0595-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
             "name": "7.0.9",
             "images": {
                 "hda_disk_image": "FAZ_VM64_KVM-v7.0.9-build0489-FORTINET.out.kvm.qcow2",
@@ -281,6 +316,13 @@
             "name": "7.0.5",
             "images": {
                 "hda_disk_image": "FAZ_VM64_KVM-v7.0.5-build0365-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "6.4.14",
+            "images": {
+                "hda_disk_image": "FAZ_VM64_KVM-v6.4.14-build2660-FORTINET.out.kvm.qcow2",
                 "hdb_disk_image": "empty30G.qcow2"
             }
         },

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -29,10 +29,24 @@
     },
     "images": [
         {
+            "filename": "FGT_VM64_KVM-v7.4.3.F-build2573-FORTINET.out.kvm.qcow2",
+            "version": "7.4.3",
+            "md5sum": "e7517095c91dce1a76a9bcf114b5fa15",
+            "filesize": 100728832,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FGT_VM64_KVM-v7.4.1.F-build2463-FORTINET.out.kvm.qcow2",
             "version": "7.4.1",
             "md5sum": "362a2f3d4ca842aaabd87191d4446584",
             "filesize": 116064256,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FGT_VM64_KVM-v7.2.7.M-build1577-FORTINET.out.kvm.qcow2",
+            "version": "7.2.7",
+            "md5sum": "752b56844e464b0b135e57f72681c288",
+            "filesize": 102760448,
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
@@ -64,6 +78,13 @@
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
+            "filename": "FGT_VM64_KVM-v7.0.14.M-build0601-FORTINET.out.kvm.qcow2",
+            "version": "7.0.14",
+            "md5sum": "20c855889e1117902bcf448b30746d30",
+            "filesize": 77398016,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FGT_VM64_KVM-v7.0.13.M-build0566-FORTINET.out.kvm.qcow2",
             "version": "7.0.13",
             "md5sum": "47a4bab29407153a635c54b64d6a226e",
@@ -89,6 +110,13 @@
             "version": "7.0.9",
             "md5sum": "0aee912ab11bf9a4b0e3fc1a62dd0e40",
             "filesize": 77135872,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FGT_VM64_KVM-v6.4.15.M-build2095-FORTINET.out.kvm.qcow2",
+            "version": "6.4.15",
+            "md5sum": "a0306a3905877de654dab7e1bb67089e",
+            "filesize": 81592320,
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
@@ -340,9 +368,23 @@
     ],
     "versions": [
         {
+            "name": "7.4.3",
+            "images": {
+                "hda_disk_image": "FGT_VM64_KVM-v7.4.3.F-build2573-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
             "name": "7.4.1",
             "images": {
                 "hda_disk_image": "FGT_VM64_KVM-v7.4.1.F-build2463-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "7.2.7",
+            "images": {
+                "hda_disk_image": "FGT_VM64_KVM-v7.2.7.M-build1577-FORTINET.out.kvm.qcow2",
                 "hdb_disk_image": "empty30G.qcow2"
             }
         },
@@ -375,6 +417,13 @@
             }
         },
         {
+            "name": "7.0.14",
+            "images": {
+                "hda_disk_image": "FGT_VM64_KVM-v7.0.14.M-build0601-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
             "name": "7.0.13",
             "images": {
                 "hda_disk_image": "FGT_VM64_KVM-v7.0.13.M-build0566-FORTINET.out.kvm.qcow2",
@@ -399,6 +448,13 @@
             "name": "7.0.9",
             "images": {
                 "hda_disk_image": "FGT_VM64_KVM-v7.0.9.M-build0444-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "6.4.15",
+            "images": {
+                "hda_disk_image": "FGT_VM64_KVM-v6.4.15.M-build2095-FORTINET.out.kvm.qcow2",
                 "hdb_disk_image": "empty30G.qcow2"
             }
         },

--- a/appliances/fortimanager.gns3a
+++ b/appliances/fortimanager.gns3a
@@ -13,7 +13,7 @@
     "status": "stable",
     "maintainer": "Ean Towne",
     "maintainer_email": "ean.fortinet@gmail.com",
-    "usage": "Default username is admin, no password is set.\n\n- Versions lower than 7.0.x require less CPU/RAM",
+    "usage": "Default username is admin, no password is set.\n\n- Versions lower than 7.0.x require less CPU/RAM\n7.4.x may require 16GB RAM.",
     "symbol": "fortinet.svg",
     "port_name_format": "Port{port1}",
     "qemu": {
@@ -29,6 +29,13 @@
         "kvm": "allow"
     },
     "images": [
+        {
+            "filename": "FMG_VM64_KVM-v7.4.2-build2397-FORTINET.out.kvm.qcow2",
+            "version": "7.4.2",
+            "md5sum": "36371fbf06210ded57c00b2ff290f2c5",
+            "filesize": 322514944,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
         {
             "filename": "FMG_VM64_KVM-v7.4.1-build2308-FORTINET.out.kvm.qcow2",
             "version": "7.4.1",
@@ -58,6 +65,13 @@
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
+            "filename": "FMG_VM64_KVM-v7.0.11-build0595-FORTINET.out.kvm.qcow2",
+            "version": "7.0.11",
+            "md5sum": "7b166222136e26190159f37cccbaab6e",
+            "filesize": 249360384,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FMG_VM64_KVM-v7.0.9-build0489-FORTINET.out.kvm.qcow2",
             "version": "7.0.9",
             "md5sum": "dbeb6a79b6e421000573dbbbdb50b8b5",
@@ -76,6 +90,13 @@
             "version": "7.0.5",
             "md5sum": "e8b9c992784cea766b52a427a5fe0279",
             "filesize": 237535232,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FMG_VM64_KVM-v6.4.14-build2660-FORTINET.out.kvm.qcow2",
+            "version": "6.4.14",
+            "md5sum": "0fe56e363b166c07b710bde795e36049",
+            "filesize": 219430912,
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
         },
         {
@@ -236,6 +257,13 @@
     ],
     "versions": [
         {
+            "name": "7.4.2",
+            "images": {
+                "hda_disk_image": "FMG_VM64_KVM-v7.4.2-build2397-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
             "name": "7.4.1",
             "images": {
                 "hda_disk_image": "FMG_VM64_KVM-v7.4.1-build2308-FORTINET.out.kvm.qcow2",
@@ -264,6 +292,13 @@
             }
         },
         {
+            "name": "7.0.11",
+            "images": {
+                "hda_disk_image": "FMG_VM64_KVM-v7.0.11-build0595-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
             "name": "7.0.9",
             "images": {
                 "hda_disk_image": "FMG_VM64_KVM-v7.0.9-build0489-FORTINET.out.kvm.qcow2",
@@ -281,6 +316,13 @@
             "name": "7.0.5",
             "images": {
                 "hda_disk_image": "FMG_VM64_KVM-v7.0.5-build0365-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "6.4.14",
+            "images": {
+                "hda_disk_image": "FMG_VM64_KVM-v6.4.14-build2660-FORTINET.out.kvm.qcow2",
                 "hdb_disk_image": "empty30G.qcow2"
             }
         },

--- a/appliances/mikrotik-rb1100ahx4-dude-edition.gns3a
+++ b/appliances/mikrotik-rb1100ahx4-dude-edition.gns3a
@@ -8,7 +8,7 @@
     "documentation_url": "http://wiki.mikrotik.com/wiki/Manual:CHR",
     "product_name": "MikroTik RouterBOARD 1100AHx4 Dude Edition",
     "product_url": "http://www.mikrotik.com/download",
-    "registry_version": 5,
+    "registry_version": 4,
     "status": "stable",
     "maintainer": "Azorian Solutions",
     "maintainer_email": "help@azorian.solutions",

--- a/appliances/mikrotik-rb450g.gns3a
+++ b/appliances/mikrotik-rb450g.gns3a
@@ -8,7 +8,7 @@
     "documentation_url": "http://wiki.mikrotik.com/wiki/Manual:CHR",
     "product_name": "MikroTik RouterBOARD 450G",
     "product_url": "http://www.mikrotik.com/download",
-    "registry_version": 5,
+    "registry_version": 4,
     "status": "stable",
     "maintainer": "Azorian Solutions",
     "maintainer_email": "help@azorian.solutions",

--- a/appliances/mikrotik-rb450gx4.gns3a
+++ b/appliances/mikrotik-rb450gx4.gns3a
@@ -8,7 +8,7 @@
     "documentation_url": "http://wiki.mikrotik.com/wiki/Manual:CHR",
     "product_name": "MikroTik RouterBOARD 450Gx4",
     "product_url": "http://www.mikrotik.com/download",
-    "registry_version": 5,
+    "registry_version": 4,
     "status": "stable",
     "maintainer": "Azorian Solutions",
     "maintainer_email": "help@azorian.solutions",


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
fortianalyzer.gns3a & fortimanager.gns3a:
+ 6.4.14
+ 7.0.11
+ 7.4.2

fortigate.gns3a:
+ 6.4.15
+ 7.0.14
+ 7.2.7
+ 7.4.3

Changed appliance version 5->4 for 3 different mikrotik appliances that were throwing warnings from check.py.