### PR TITLE
Adding CHR v7.14.2

### DIFF
--- a/appliances/mikrotik-chr.gns3a
+++ b/appliances/mikrotik-chr.gns3a
@@ -28,6 +28,15 @@
     },
     "images": [
         {
+            "filename": "chr-7.14.2.img",
+            "version": "7.14.2",
+            "md5sum": "531901dac85b67b23011e946a62abc7b",
+            "filesize": 134217728,
+            "download_url": "http://www.mikrotik.com/download",
+            "direct_download_url": "https://download.mikrotik.com/routeros/7.14.2/chr-7.14.2.img.zip",
+            "compression": "zip"
+        },
+        {
             "filename": "chr-7.11.2.img",
             "version": "7.11.2",
             "md5sum": "fbffd097d2c5df41fc3335c3977f782c",


### PR DESCRIPTION
I added the MikroTik CHR with version 7.14.2.
![image](https://github.com/GNS3/gns3-registry/assets/97678748/e22efbc6-e1e4-41ff-8c65-7e56bab37868)

Please merge my PR to make this available to the community.

Procedure:
Downloaded .img file from MikroTik Website
Verify downloaded zip: `sha256sum chr-7.14.2.img.zip` Extract contents: `unzip sha256sum chr-7.14.2.img.zip` Get MD5 Hash: `md5sum chr-7.14.2.img`
Get Filesize: `du -sb ./chr-7.14.2.img`

Added information to mikrotik-chr.gns3a

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ ] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
