### PR TITLE
pyats - Disable building Docker image

### DIFF
--- a/docker/docker_images
+++ b/docker/docker_images
@@ -16,7 +16,8 @@ mikrotik-winbox		mikrotik-winbox
 ostinato-wireshark	ostinato-wireshark
 openvswitch		openvswitch
 ovs-snmp		ovs-snmp			--platform=linux/arm64
-pyats			pyats
+# pyats: fails to build on ubuntu 24.04 (noble)
+#pyats			pyats
 ubuntu:focal		ubuntu
 
 # Tests


### PR DESCRIPTION
As noted in https://github.com/GNS3/gns3-registry/issues/879, the `pyats` docker image currently fails to build. Therefore its automatic build needs to be disabled.