### PR TITLE
openvswitch - IP configuration for bridge interfaces

### DIFF
--- a/docker/openvswitch/init.sh
+++ b/docker/openvswitch/init.sh
@@ -46,7 +46,9 @@ if [ $firstrun -ne 0 ]; then
   done
 fi
 
-# activate br0..br3
-for intf in br0 br1 br2 br3; do
-  ip link set dev $intf up
+# activate bridge interfaces
+ovs-vsctl --bare -f table --columns=name find interface type=internal | \
+while read -r intf; do
+  ip link set dev "$intf" up
+  ifup -f "$intf"
 done


### PR DESCRIPTION
This PR allows to use /etc/network/interfaces to setup the IP configuration for the bridge interfaces (br0, br1, ...).

Only the bridge interfaces should not be marked as `auto` interfaces, as at the the time the initial IP configuration is applied these bridge interfaces don't exist. Therefore this would result in a (harmless) warning.

Here an example, there is nothing special:

```
# Static config for br0
#auto br0
iface br0 inet static
	address 10.1.1.1
	netmask 255.255.255.0
```

Furthermore the name of the bridge interface are not fixed, they are retrieved from the database. That makes the initialization of the bridge interfaces more flexible.