### PR TITLE
Debian: Update to versions 12.6 and 11.10, remove netplan

### DIFF
--- a/appliances/debian.gns3a
+++ b/appliances/debian.gns3a
@@ -24,12 +24,28 @@
     },
     "images": [
         {
+            "filename": "debian-12.6.qcow2",
+            "version": "12.6",
+            "md5sum": "04753ba14295c6414d49bffe27b676ae",
+            "filesize": 280907776,
+            "download_url": "https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/",
+            "direct_download_url": "https://downloads.sourceforge.net/project/gns-3/Qemu%20Appliances/debian-12.6.qcow2"
+        },
+        {
             "filename": "debian-12.4.qcow2",
             "version": "12.4",
             "md5sum": "adcf7fdc25e10b3d2d9e2ef91168bffd",
             "filesize": 286179840,
             "download_url": "https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/",
             "direct_download_url": "https://downloads.sourceforge.net/project/gns-3/Qemu%20Appliances/debian-12.4.qcow2"
+        },
+        {
+            "filename": "debian-11.10.qcow2",
+            "version": "11.10",
+            "md5sum": "99a1dc8e110d641309674e69b630e732",
+            "filesize": 263520256,
+            "download_url": "https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/",
+            "direct_download_url": "https://downloads.sourceforge.net/project/gns-3/Qemu%20Appliances/debian-11.10.qcow2"
         },
         {
             "filename": "debian-11.8.qcow2",
@@ -42,9 +58,21 @@
     ],
     "versions": [
         {
+            "name": "12.6",
+            "images": {
+                "hda_disk_image": "debian-12.6.qcow2"
+            }
+        },
+        {
             "name": "12.4",
             "images": {
                 "hda_disk_image": "debian-12.4.qcow2"
+            }
+        },
+        {
+            "name": "11.10",
+            "images": {
+                "hda_disk_image": "debian-11.10.qcow2"
             }
         },
         {

--- a/packer/debian/debian-11.json
+++ b/packer/debian/debian-11.json
@@ -1,5 +1,5 @@
 {
-    "iso_url": "https://cloud.debian.org/images/cloud/bullseye/20231013-1532/debian-11-genericcloud-amd64-20231013-1532.qcow2",
-    "iso_checksum": "b3b2f6b3411ea6e2f097a91b579ad2838611d5cdf8fbd1089435c55f9c6bb398",
+    "iso_url": "https://cloud.debian.org/images/cloud/bullseye/20240702-1796/debian-11-genericcloud-amd64-20240702-1796.qcow2",
+    "iso_checksum": "d236925c59ede4ab634141ca5433f1caa38dbdc0a1df438c57ee4115754014b1",
     "vm_name": "debian-11.qcow2"
 }

--- a/packer/debian/debian.json
+++ b/packer/debian/debian.json
@@ -1,7 +1,7 @@
 {
     "variables": {
-        "iso_url": "https://cloud.debian.org/images/cloud/bookworm/20231210-1591/debian-12-genericcloud-amd64-20231210-1591.qcow2",
-        "iso_checksum": "16e360b50572092ff5c1ed994285bcca961df28c081b7bb5d7c006d35bce4914",
+        "iso_url": "https://cloud.debian.org/images/cloud/bookworm/20240702-1796/debian-12-genericcloud-amd64-20240702-1796.qcow2",
+        "iso_checksum": "a4bc7fa86ef51d2b059ce0abd9c6130b4c36a3449b8a130bb509602924e9e6e7",
         "disk_size": "2G",
         "vm_name": "debian.qcow2",
         "setup_script": "debian.sh"

--- a/packer/debian/scripts/networking.sh
+++ b/packer/debian/scripts/networking.sh
@@ -8,14 +8,17 @@ else
 	printf '127.0.1.1\t%s\t%s\n' "$(hostname -f)" "$(hostname)" >> /etc/hosts
 fi
 
-# replace systemd-resolved by resolvconf
-cp /etc/resolv.conf /etc/resolv.conf.orig
+# replace netplan and systemd-resolved by ifupdown and resolvconf
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get -y upgrade
+cp /etc/resolv.conf /etc/resolv.conf.orig
 apt-get -y install --purge ifupdown resolvconf
 cat /etc/resolv.conf.orig > /etc/resolv.conf
 rm -f /etc/resolv.conf.orig
+echo "network: {config: disabled}" > /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
+rm -rf /etc/netplan
+apt-get -y autoremove --purge netplan.io
 
 # replace cloud-init network configuration
 cat > /etc/network/interfaces <<'EOF'


### PR DESCRIPTION
On version 12.6 I removed `netplan`, as it doesn't seem to work well with `resolvconf`. Anyway, the appliance was made for using `ifupdown`.

@grossmj If you like to use my images, download them from <https://github.com/b-ehlers/gns3-registry/releases/tag/debian> and upload them to <https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/>. Otherwise you can build the images yourself with packer, then you have to adapt the size and md5sum in the appliance.

---

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---