### PR TITLE
Updating fortimanager, fortianalyzer, and fortigate appliance files for latest 7.4.x

### DIFF
--- a/appliances/fortianalyzer.gns3a
+++ b/appliances/fortianalyzer.gns3a
@@ -299,6 +299,27 @@
     ],
     "versions": [
         {
+            "name": "7.4.6",
+            "images": {
+                "hda_disk_image": "FAZ_VM64_KVM-v7.4.6.M-build2588-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "7.4.5",
+            "images": {
+                "hda_disk_image": "FAZ_VM64_KVM-v7.4.5.M-build2553-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "7.4.4",
+            "images": {
+                "hda_disk_image": "FAZ_VM64_KVM-v7.4.4.F-build2550-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
             "name": "7.4.3",
             "images": {
                 "hda_disk_image": "FAZ_VM64_KVM-v7.4.3-build2487-FORTINET.out.kvm.qcow2",

--- a/appliances/fortianalyzer.gns3a
+++ b/appliances/fortianalyzer.gns3a
@@ -30,6 +30,27 @@
     },
     "images": [
         {
+            "filename": "FAZ_VM64_KVM-v7.4.6.M-build2588-FORTINET.out.kvm.qcow2",
+            "version": "7.4.6",
+            "md5sum": "fba982436ff430465df6f6f283a2bd71",
+            "filesize": 511053824,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FAZ_VM64_KVM-v7.4.5.M-build2553-FORTINET.out.kvm.qcow2",
+            "version": "7.4.5",
+            "md5sum": "78464ee460fce69c360901ca9ccfe4a0",
+            "filesize": 510988288,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FAZ_VM64_KVM-v7.4.4.F-build2550-FORTINET.out.kvm.qcow2",
+            "version": "7.4.4",
+            "md5sum": "7bec1725b1e39dd66f4daae07492f1b4",
+            "filesize": 511217664,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FAZ_VM64_KVM-v7.4.3-build2487-FORTINET.out.kvm.qcow2",
             "version": "7.4.3",
             "md5sum": "c58709af18516763ed88f58621447bf6",

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -410,6 +410,27 @@
     ],
     "versions": [
         {
+            "name": "7.4.7",
+            "images": {
+                "hda_disk_image": "FGT_VM64_KVM-v7.4.7.M-build2731-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "7.4.6",
+            "images": {
+                "hda_disk_image": "FGT_VM64_KVM-v7.4.6.M-build2726-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "7.4.5",
+            "images": {
+                "hda_disk_image": "FGT_VM64_KVM-v7.4.5.M-build2702-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
             "name": "7.4.4",
             "images": {
                 "hda_disk_image": "FGT_VM64_KVM-v7.4.4.F-build2662-FORTINET.out.kvm.qcow2",

--- a/appliances/fortigate.gns3a
+++ b/appliances/fortigate.gns3a
@@ -29,6 +29,27 @@
     },
     "images": [
         {
+            "filename": "FGT_VM64_KVM-v7.4.7.M-build2731-FORTINET.out.kvm.qcow2",
+            "version": "7.4.7",
+            "md5sum": "2ce4039789e84b3fe85565e0c4110718",
+            "filesize": 103677952,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FGT_VM64_KVM-v7.4.6.M-build2726-FORTINET.out.kvm.qcow2",
+            "version": "7.4.6",
+            "md5sum": "b787c1c5ab365f267d7e4e88b1cdc10b",
+            "filesize": 103677952,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FGT_VM64_KVM-v7.4.5.M-build2702-FORTINET.out.kvm.qcow2",
+            "version": "7.4.5",
+            "md5sum": "8465e74c4ef1751619ebb989838d457c",
+            "filesize": 102367232,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FGT_VM64_KVM-v7.4.4.F-build2662-FORTINET.out.kvm.qcow2",
             "version": "7.4.4",
             "md5sum": "dfe0e78827ec728631539669001bb23f",

--- a/appliances/fortimanager.gns3a
+++ b/appliances/fortimanager.gns3a
@@ -30,8 +30,29 @@
     },
     "images": [
         {
+            "filename": "FMG_VM64_KVM-v7.4.6.M-build2588-FORTINET.out.kvm.qcow2",
+            "version": "7.4.6",
+            "md5sum": "7cb219e1070d393f61cf750d818b23b1",
+            "filesize": 349122560,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FMG_VM64_KVM-v7.4.5.M-build2553-FORTINET.out.kvm.qcow2",
+            "version": "7.4.5",
+            "md5sum": "fa59ddce0cb933741f16866472026723",
+            "filesize": 349769728,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
+            "filename": "FMG_VM64_KVM-v7.4.4.F-build2550-FORTINET.out.kvm.qcow2",
+            "version": "7.4.4",
+            "md5sum": "770727bb30555e6938308bbf95f19555",
+            "filesize": 349847552,
+            "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"
+        },
+        {
             "filename": "FMG_VM64_KVM-v7.4.3-build2487-FORTINET.out.kvm.qcow2",
-            "version": "7.4.23",
+            "version": "7.4.3",
             "md5sum": "b01d9f86aa27c538407d518df1326863",
             "filesize": 346107904,
             "download_url": "https://support.fortinet.com/Download/FirmwareImages.aspx"

--- a/appliances/fortimanager.gns3a
+++ b/appliances/fortimanager.gns3a
@@ -299,6 +299,27 @@
     ],
     "versions": [
         {
+            "name": "7.4.6",
+            "images": {
+                "hda_disk_image": "FMG_VM64_KVM-v7.4.6.M-build2588-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "7.4.5",
+            "images": {
+                "hda_disk_image": "FMG_VM64_KVM-v7.4.5.M-build2553-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
+            "name": "7.4.4",
+            "images": {
+                "hda_disk_image": "FMG_VM64_KVM-v7.4.4.F-build2550-FORTINET.out.kvm.qcow2",
+                "hdb_disk_image": "empty30G.qcow2"
+            }
+        },
+        {
             "name": "7.4.3",
             "images": {
                 "hda_disk_image": "FMG_VM64_KVM-v7.4.3-build2487-FORTINET.out.kvm.qcow2",


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
