### PR TITLE
Adding Updated Alma, Rocky, & Oracle Cloud Images

### DIFF
--- a/appliances/almalinux.gns3a
+++ b/appliances/almalinux.gns3a
@@ -26,12 +26,28 @@
     },
     "images": [
         {
+            "filename": "AlmaLinux-9-GenericCloud-9.4-20240805.x86_64.qcow2",
+            "version": "9.4",
+            "md5sum": "7c5040c044a989c524d40824cebb4a4d",
+            "filesize": 591724544,
+            "download_url": "https://vault.almalinux.org/9.4/cloud/x86_64/images/",
+            "direct_download_url": "https://vault.almalinux.org/9.4/cloud/x86_64/images/AlmaLinux-9-GenericCloud-9.4-20240805.x86_64.qcow2"
+        },
+        {
             "filename": "AlmaLinux-9-GenericCloud-9.2-20230513.x86_64.qcow2",
             "version": "9.2",
             "md5sum": "c5bc76e8c95ac9f810a3482c80a54cc7",
             "filesize": 563347456,
             "download_url": "https://vault.almalinux.org/9.2/cloud/x86_64/images/",
             "direct_download_url": "https://vault.almalinux.org/9.2/cloud/x86_64/images/AlmaLinux-9-GenericCloud-9.2-20230513.x86_64.qcow2"
+        },
+        {
+            "filename": "AlmaLinux-8-GenericCloud-8.9-20231128.x86_64.qcow2",
+            "version": "8.9",
+            "md5sum": "1afc48c798960f0c6ebb65428c0ea973",
+            "filesize": 697434112,
+            "download_url": "https://vault.almalinux.org/8.9/cloud/x86_64/images/",
+            "direct_download_url": "https://vault.almalinux.org/8.9/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.9-20231128.x86_64.qcow2"
         },
         {
             "filename": "AlmaLinux-8-GenericCloud-8.8-20230524.x86_64.qcow2",
@@ -60,9 +76,23 @@
     ],
     "versions": [
         {
+            "name": "9.4",
+            "images": {
+                "hda_disk_image": "AlmaLinux-9-GenericCloud-9.4-20240805.x86_64.qcow2",
+                "cdrom_image": "almalinux-cloud-init-data.iso"
+            }
+        },
+        {
             "name": "9.2",
             "images": {
                 "hda_disk_image": "AlmaLinux-9-GenericCloud-9.2-20230513.x86_64.qcow2",
+                "cdrom_image": "almalinux-cloud-init-data.iso"
+            }
+        },
+        {
+            "name": "8.9",
+            "images": {
+                "hda_disk_image": "AlmaLinux-8-GenericCloud-8.9-20231128.x86_64.qcow2",
                 "cdrom_image": "almalinux-cloud-init-data.iso"
             }
         },

--- a/appliances/oracle-linux-cloud.gns3a
+++ b/appliances/oracle-linux-cloud.gns3a
@@ -27,6 +27,14 @@
     },
     "images": [
         {
+            "filename": "OL9U5_x86_64-kvm-b259.qcow2",
+            "version": "9.5",
+            "md5sum": "05e9b62c408ab49a02d6833fc683d1ad",
+            "filesize": 652935168,
+            "download_url": "https://yum.oracle.com/oracle-linux-templates.html",
+            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL9/u5/x86_64/OL9U5_x86_64-kvm-b259.qcow2"
+        },
+        {
             "filename": "OL9U2_x86_64-kvm-b197.qcow",
             "version": "9.2",
             "md5sum": "2ff3d0bc8a243ad89c96215f303f1c73",
@@ -41,6 +49,14 @@
             "filesize": 539033600,
             "download_url": "https://yum.oracle.com/oracle-linux-templates.html",
             "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL9/u1/x86_64/OL9U1_x86_64-kvm-b158.qcow"
+        },
+        {
+            "filename": "OL8U10_x86_64-kvm-b258.qcow2",
+            "version": "8.10",
+            "md5sum": "bb07581af5122515b6822595ded5deef",
+            "filesize": 1251672064,
+            "download_url": "https://yum.oracle.com/oracle-linux-templates.html",
+            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL8/u10/x86_64/OL8U10_x86_64-kvm-b258.qcow2"
         },
         {
             "filename": "OL8U8_x86_64-kvm-b198.qcow",
@@ -76,7 +92,14 @@
         }
     ],
     "versions": [
-{
+        {
+            "name": "9.5",
+            "images": {
+                "hda_disk_image": "OL9U5_x86_64-kvm-b259.qcow2",
+                "cdrom_image": "oracle-cloud-init-data.iso"
+            }
+        },
+        {
             "name": "9.2",
             "images": {
                 "hda_disk_image": "OL9U2_x86_64-kvm-b197.qcow",
@@ -87,6 +110,13 @@
             "name": "9.1",
             "images": {
                 "hda_disk_image": "OL9U1_x86_64-kvm-b158.qcow",
+                "cdrom_image": "oracle-cloud-init-data.iso"
+            }
+        },
+        {
+            "name": "8.10",
+            "images": {
+                "hda_disk_image": "OL8U10_x86_64-kvm-b258.qcow2",
                 "cdrom_image": "oracle-cloud-init-data.iso"
             }
         },

--- a/appliances/rockylinux.gns3a
+++ b/appliances/rockylinux.gns3a
@@ -27,6 +27,14 @@
     },
     "images": [
         {
+            "filename": "Rocky-9-GenericCloud-Base-9.5-20241118.0.x86_64.qcow2",
+            "version": "9.5",
+            "md5sum": "880eccf788301bb9f34669faebe09276",
+            "filesize": 609812480,
+            "download_url": "https://download.rockylinux.org/pub/rocky/9/images/x86_64/",
+            "direct_download_url": "https://download.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base-9.5-20241118.0.x86_64.qcow2"
+        },
+        {
             "filename": "Rocky-9-GenericCloud-Base-9.3-20231113.0.x86_64.qcow2",
             "version": "9.3",
             "md5sum": "48cdeb033364af5909e15ee48d0e144d",
@@ -68,6 +76,13 @@
         }
     ],
     "versions": [
+        {
+            "name": "9.5",
+            "images": {
+                "hda_disk_image": "Rocky-9-GenericCloud-Base-9.5-20241118.0.x86_64.qcow2",
+                "cdrom_image": "rocky-cloud-init-data.iso"
+            }
+        },
         {
             "name": "9.3",
             "images": {


### PR DESCRIPTION
---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.

The PR is for:-

AlmaLinux-8.9
AlmaLinux-9.4
RockyLinux-9.5
Oracle Linux Cloud Images 8.10
Oracle Linux Cloud Images 9.5

All 5 Images have been Booted and Logged into locally using GNS3 v2.2.58