### PR TITLE
Update cisco-iou-l3.gns3a

### DIFF
--- a/appliances/cisco-iou-l3.gns3a
+++ b/appliances/cisco-iou-l3.gns3a
@@ -22,6 +22,12 @@
     "images": [
         {
             "filename": "x86_64_crb_linux-adventerprisek9-ms.iol",
+            "version": "17.16.01a",
+            "md5sum": "39bdf959c3b99a3c81d66451f1cf0404",
+            "filesize": 293062920
+        },
+        {
+            "filename": "x86_64_crb_linux-adventerprisek9-ms.iol",
             "version": "17.15.1",
             "md5sum": "5d584f6cfbeaadc87d55f613da1049ed",
             "filesize": 292001512
@@ -52,6 +58,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "17.16.01a",
+            "images": {
+                "image": "x86_64_crb_linux-adventerprisek9-ms.iol"
+            }
+        },
         {
             "name": "17.15.1",
             "images": {


### PR DESCRIPTION
Add version 17.16.01a

Before submitting a pull request, please check the following.

- The file provided by Cisco has the same filename as the previous version, so it isn't unique and will overwrite the previous version. Not sure what to do about this conflict.
- The new IOU images from CML require the "Use default IOU values for memories" box to be unchecked, which is a tweak I don't know how to make within the appliance file. The default values don't have enough memory to store the startup-config.
- The 17.16.01a version for IOU-L2 has all of these same issues, so I'll hold off on that pull request till this IOU-L3 version passes.
---
When updating an **existing** appliance:
- [x] The new version is on top.
- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ ] If you forked the repo, running check.py doesn't drop any errors for the updated file.

