### PR TITLE
Add Cisco 7200 IP Transfer Point image.

### DIFF
--- a/appliances/cisco-7200.gns3a
+++ b/appliances/cisco-7200.gns3a
@@ -50,6 +50,12 @@
             "version": "124-25G",
             "md5sum": "9c7cc9b3f3b3571411a7f62faaa2c036",
             "filesize": 71528984
+        },
+        {
+            "filename": "c7200-itpk9-mz.124-15.SW.image",
+            "version": "124-15.SW",
+            "md5sum": "3334a0facdbd26164e83d3c201fff5b5",
+            "filesize": 46423952
         }
     ],
     "versions": [
@@ -86,6 +92,13 @@
             "idlepc": "0x6066a998",
             "images": {
                 "image": "c7200-a3jk9s-mz.124-25g.image"
+            }
+        },
+        {
+            "name": "124-15.SW",
+            "idlepc": "0x60b2bc68",
+            "images": {
+                "image": "c7200-itpk9-mz.124-15.SW.image"
             }
         }
     ]


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ ] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---

I tried to check if on my GNS3 VM via the Web UI, but appliance upload doesn't work.
However, manually using the image works fine.

The .image is created by unzipping the .bin, as usual. md5sum is self explanatory.