### PR TITLE
feature: add mikrotik 2026 winbox appliance

### DIFF
--- a/appliances/mikrotik-winbox-2026.gns3a
+++ b/appliances/mikrotik-winbox-2026.gns3a
@@ -1,0 +1,22 @@
+{
+    "appliance_id": "1174e46d-4a29-4554-a1e8-71ed90682295",
+    "name": "MikroTik WinBox 2026",
+    "category": "guest",
+    "description": "Mikrotik's WinBox router management software for GNS3 2026",
+    "vendor_name": "MikroTik",
+    "vendor_url": "https://mikrotik.com",
+    "documentation_url": "https://mikrotik.com/winbox",
+    "product_name": "MikroTik WinBox",
+    "product_url": "https://mikrotik.com/winbox",
+    "registry_version": 4,
+    "status": "stable",
+    "availability": "free",
+    "maintainer": "h3ck13r",
+    "maintainer_email": "pisdushko1886@gmail.com",
+    "usage": "Connect WinBox to a MikroTik CHR port and start them both. Open WinBox console and wait until MikroTik appear in neighbors tab, provide credentials and connect.",
+    "docker": {
+        "adapters": 1,
+        "image": "snatao808/winbox-mikrotik-2026",
+        "console_type": "vnc"
+    }
+}


### PR DESCRIPTION
Hello.
Added a new WinBox MikroTik 2026 (4.0beta44) appliance. This is a docker image built on ubuntu 22.04 with the newest WinBox. VNC verified working correctly both locally (docker on linux mint PC) and inside GNS3 in pair with MikroTik CHR 7.16.

When creating a new appliance:

    It's tested locally, i.e.
        [+] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
        [-] GNS3 VM can run it without any tweaks.
        I ran GNS3 locally on my linux mint 22.1 and I failed multiple times to install a VM for GNS3 so i cannot confirm that point.
        [+] The device is in the right category: router, switch, guest (hosts), firewall
        [+] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
    [+] When adding a container: it builds on Docker Hub and can be pulled.
    [+] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
    [+] If you forked the repo, running check.py doesn't drop any errors for the new file.
    [-] Optional: a symbol has been created for the new appliance.

<img width="353" height="223" alt="image" src="https://github.com/user-attachments/assets/50fd2dd2-6995-445f-8946-ab7ae80a1218" />
<img width="1023" height="696" alt="image" src="https://github.com/user-attachments/assets/6f23b1be-517f-456d-abe1-b3b437ce22fa" />
<img width="1023" height="698" alt="image" src="https://github.com/user-attachments/assets/50787719-2033-4461-94bf-8459b746d13a" />