### PR TITLE
Increase minimum RAM requirement for AsterNOS-VPP

### DIFF
--- a/appliances/asterfusion-vAsterNOS-VPP.gns3a
+++ b/appliances/asterfusion-vAsterNOS-VPP.gns3a
@@ -2,7 +2,7 @@
     "appliance_id": "4aa78f74-c769-43e0-9ef1-5dd2cf1909c6",
     "name": "Asterfusion AsterNOS-VPP",
     "category": "router",
-    "description": "AsterNOS-VPP leverages SONiC’s robust routing features and management capability with VPP’s high-performance data forwarding. It supports L3 routing, NAT, PPPoE, and VPN services. Minimum requirements: 4 vCPUs and 4GB RAM.",
+    "description": "AsterNOS-VPP leverages SONiC’s robust routing features and management capability with VPP’s high-performance data forwarding. It supports L3 routing, NAT, PPPoE, and VPN services. Minimum requirements: 4 vCPUs and 8GB RAM.",
     "vendor_name": "Asterfusion",
     "vendor_url": "https://cloudswit.ch/product/sonic-enterprise-distribution/#vAsterNOS",
     "documentation_url": "https://docs.asternos.com/routing",
@@ -24,7 +24,7 @@
     "qemu": {
         "adapter_type": "virtio-net-pci",
         "adapters": 4,
-        "ram": 4096,
+        "ram": 8192,
         "cpus": 4,
         "arch": "x86_64",
         "console_type": "telnet",


### PR DESCRIPTION
Updated minimum RAM requirement from 4GB to 8GB.

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [ ] The new version is on top.
- [ ] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ ] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
