### PR TITLE
Update vJunos router first port and number of adapters

### DIFF
--- a/appliances/juniper-vJunos-router.gns3a
+++ b/appliances/juniper-vJunos-router.gns3a
@@ -14,11 +14,11 @@
     "maintainer_email": "github@sugarpapa.mozmail.com",
     "usage": "GNS3 SHOULD be a baremetal installation. Using the GNS3 VM MIGHT result in unwanted issues. Default user is root. No password is needed.",
     "symbol": "juniper-vmx.svg",
-    "first_port_name": "ge-0/0/0",
+    "first_port_name": "fxp0",
     "port_name_format": "ge-0/0/{port0}",
     "qemu": {
         "adapter_type": "virtio-net-pci",
-        "adapters": 17,
+        "adapters": 10,
         "ram": 5120,
         "cpus": 4,
         "hda_disk_interface": "virtio",


### PR DESCRIPTION
All supported vJunos images have 10 adapters by default, and the first port should be fxp0. Currently, with first port ge-0/0/0 there are two ge-0/0/0 ports.

---

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
