### PR TITLE
add opnsense 26.1, fix 25.7 25.1

### DIFF
--- a/appliances/opnsense.gns3a
+++ b/appliances/opnsense.gns3a
@@ -26,6 +26,15 @@
     },
     "images": [
         {
+            "filename": "OPNsense-26.1-nano-amd64.img",
+            "version": "26.1",
+            "md5sum": "3b774e8fb651a5d00aa6fa3e0d1b1ff0",
+            "filesize": 3221225472,
+            "download_url": "https://opnsense.c0urier.net/releases/26.1/",
+            "direct_download_url": "https://opnsense.c0urier.net/releases/26.1/OPNsense-26.1-nano-amd64.img.bz2",
+            "compression": "bzip2"
+        },
+        {
             "filename": "OPNsense-25.7-nano-amd64.img",
             "version": "25.7",
             "md5sum": "07aa8b44ebc57fa9ca0145f777901a59",
@@ -90,6 +99,24 @@
         }
     ],
     "versions": [
+        {
+            "name": "26.1",
+            "images": {
+                "hda_disk_image": "OPNsense-26.1-nano-amd64.img"
+            }
+        },
+        {
+            "name": "25.7",
+            "images": {
+                "hda_disk_image": "OPNsense-25.7-nano-amd64.img"
+            }
+        },
+        {
+            "name": "25.1",
+            "images": {
+                "hda_disk_image": "OPNsense-25.1-nano-amd64.img"
+            }
+        },
         {
             "name": "24.7",
             "images": {


### PR DESCRIPTION
Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [ ] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [ ] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
