### PR TITLE
  Add device_type tags to Cisco IOS appliance definitions for better categorization and identification.                                    

### DIFF
--- a/appliances/cisco-1700.gns3a
+++ b/appliances/cisco-1700.gns3a
@@ -1,5 +1,6 @@
 {
     "appliance_id": "cc2b1802-3520-4963-8ff7-c19b1f6418c5",
+    "tags": ["device_type:cisco_ios_telnet"],
     "name": "Cisco 1700",
     "category": "router",
     "description": "Cisco 1700 Router",

--- a/appliances/cisco-2600.gns3a
+++ b/appliances/cisco-2600.gns3a
@@ -1,5 +1,6 @@
 {
     "appliance_id": "ed474fea-cd3b-4e2e-be84-a855a133060a",
+    "tags": ["device_type:cisco_ios_telnet"],
     "name": "Cisco 2600",
     "category": "router",
     "description": "Cisco 2600 Router",

--- a/appliances/cisco-2691.gns3a
+++ b/appliances/cisco-2691.gns3a
@@ -1,5 +1,6 @@
 {
     "appliance_id": "ed0f079e-a506-4cb4-b46c-714a80bbe2d3",
+    "tags": ["device_type:cisco_ios_telnet"],
     "name": "Cisco 2691",
     "category": "router",
     "description": "Cisco 2691 Router",

--- a/appliances/cisco-3620.gns3a
+++ b/appliances/cisco-3620.gns3a
@@ -1,5 +1,6 @@
 {
     "appliance_id": "7ada6336-7280-4306-9f32-6b1e242ae989",
+    "tags": ["device_type:cisco_ios_telnet"],
     "name": "Cisco 3620",
     "category": "router",
     "description": "Cisco 3620 Router",

--- a/appliances/cisco-3640.gns3a
+++ b/appliances/cisco-3640.gns3a
@@ -1,5 +1,6 @@
 {
     "appliance_id": "ef119e49-19fe-4239-9c6b-16ea12f6ec01",
+    "tags": ["device_type:cisco_ios_telnet"],
     "name": "Cisco 3640",
     "category": "router",
     "description": "Cisco 3640 Router",

--- a/appliances/cisco-3660.gns3a
+++ b/appliances/cisco-3660.gns3a
@@ -1,5 +1,6 @@
 {
     "appliance_id": "ac460a9c-9274-4ccf-a056-af50b699925f",
+    "tags": ["device_type:cisco_ios_telnet"],
     "name": "Cisco 3660",
     "category": "router",
     "description": "Cisco 3660 Router",

--- a/appliances/cisco-3725.gns3a
+++ b/appliances/cisco-3725.gns3a
@@ -1,5 +1,6 @@
 {
     "appliance_id": "5b9c5293-a5a7-47a3-9df4-6cf658f2f378",
+    "tags": ["device_type:cisco_ios_telnet"],
     "name": "Cisco 3725",
     "category": "router",
     "description": "Cisco 3725 Router",

--- a/appliances/cisco-3745.gns3a
+++ b/appliances/cisco-3745.gns3a
@@ -1,5 +1,6 @@
 {
     "appliance_id": "18737edb-e43f-4fb0-8a0f-88982cff58b1",
+    "tags": ["device_type:cisco_ios_telnet"],
     "name": "Cisco 3745",
     "category": "router",
     "description": "Cisco 3745 Multiservice Access Router",

--- a/appliances/cisco-7200.gns3a
+++ b/appliances/cisco-7200.gns3a
@@ -1,5 +1,6 @@
 {
     "appliance_id": "38aa3135-f169-4131-9b64-73605787b5ef",
+    "tags": ["device_type:cisco_ios_telnet"],
     "name": "Cisco 7200",
     "category": "router",
     "description": "Cisco 7200 Router",

--- a/appliances/cisco-iosv.gns3a
+++ b/appliances/cisco-iosv.gns3a
@@ -1,5 +1,6 @@
 {
     "appliance_id": "3bf492b6-5717-4257-9bfd-b34617c6f133",
+    "tags": ["device_type:cisco_ios_telnet"],
     "name": "Cisco IOSv",
     "category": "router",
     "description": "Cisco Virtual IOS allows user to run IOS on a standard computer.",

--- a/appliances/cisco-iosvl2.gns3a
+++ b/appliances/cisco-iosvl2.gns3a
@@ -1,5 +1,6 @@
 {
     "appliance_id": "4368f802-ddec-4863-adbd-a36a6d83cd4c",
+    "tags": ["device_type:cisco_ios_telnet"],
     "name": "Cisco IOSvL2",
     "category": "multilayer_switch",
     "description": "Cisco Virtual IOS L2 allows user to run a IOS switching image on a standard computer.",

--- a/appliances/cisco-iou-l2.gns3a
+++ b/appliances/cisco-iou-l2.gns3a
@@ -1,5 +1,6 @@
 {
     "appliance_id": "9593db48-558a-4914-bb78-a20605f39c65",
+    "tags": ["device_type:cisco_ios_telnet"],
     "name": "Cisco IOU L2",
     "category": "multilayer_switch",
     "description": "Cisco IOS on UNIX Layer 2 image.",

--- a/appliances/cisco-iou-l3.gns3a
+++ b/appliances/cisco-iou-l3.gns3a
@@ -1,5 +1,6 @@
 {
     "appliance_id": "87bf6f58-1e5a-4ee2-afe7-715dabffcf18",
+    "tags": ["device_type:cisco_ios_telnet"],
     "name": "Cisco IOU L3",
     "category": "router",
     "description": "Cisco IOS on UNIX Layer 3 image.",

--- a/appliances/huawei-ce12800.gns3a
+++ b/appliances/huawei-ce12800.gns3a
@@ -1,5 +1,6 @@
 {
     "appliance_id": "bd86792e-9870-4b42-8f16-cb2776f1d5d5",
+    "tags": ["device_type:gns3_huawei_telnet_ce"],
     "name": "HuaWei CE12800",
     "category": "multilayer_switch",
     "description": "CE12800 series switches are high-performance core switches designed for data center networks and high-end campus networks. The switches provide stable, reliable, secure, and high-performance Layer 2/Layer 3 switching services, to help build an elastic, virtualized, agile, and high-quality network.",

--- a/schemas/appliance_v4.json
+++ b/schemas/appliance_v4.json
@@ -25,6 +25,13 @@
       "type": "string",
       "title": "Appliance name"
     },
+    "tags": {
+      "type": "array",
+      "title": "Tags for the appliance",
+      "items": {
+        "type": "string"
+      }
+    },
     "category": {
       "enum": [
           "router",

--- a/schemas/appliance_v5.json
+++ b/schemas/appliance_v5.json
@@ -25,6 +25,13 @@
       "type": "string",
       "title": "Appliance name"
     },
+    "tags": {
+      "type": "array",
+      "title": "Tags for the appliance",
+      "items": {
+        "type": "string"
+      }
+    },
     "category": {
       "enum": [
           "router",

--- a/schemas/appliance_v6.json
+++ b/schemas/appliance_v6.json
@@ -25,6 +25,13 @@
       "type": "string",
       "title": "Appliance name"
     },
+    "tags": {
+      "type": "array",
+      "title": "Tags for the appliance",
+      "items": {
+        "type": "string"
+      }
+    },
     "category": {
       "enum": [
           "router",

--- a/schemas/appliance_v7.json
+++ b/schemas/appliance_v7.json
@@ -25,6 +25,13 @@
       "type": "string",
       "title": "Appliance name"
     },
+    "tags": {
+      "type": "array",
+      "title": "Tags for the appliance",
+      "items": {
+        "type": "string"
+      }
+    },
     "category": {
       "enum": [
           "router",

--- a/schemas/appliance_v8.json
+++ b/schemas/appliance_v8.json
@@ -581,6 +581,13 @@
       "type": "string",
       "title": "Appliance name"
     },
+    "tags": {
+      "type": "array",
+      "title": "Tags for the appliance",
+      "items": {
+        "type": "string"
+      }
+    },
     "category": {
       "$ref": "#/definitions/categories",
       "title": "Category of the appliance"


### PR DESCRIPTION
                                                                                                                                          
  **Changes**                                                                                                                                  
                                                                                                                                           
  - Added tags field with device_type:cisco_ios_telnet to Cisco IOS router appliances (1700, 2600, 2691, 3620, 3640, 3660, 3725, 3745, 7200)                                                                                                                                    
  - Added tags field with device_type:cisco_ios_telnet to IOSv and IOSvL2 appliances                                                       
  - Added tags field with device_type:cisco_ios_telnet to IOU L2/L3 appliances                                                             
  - Added device_type:gns3_huawei_telnet_ce tag to Huawei CE12800 appliance           