### PR TITLE
Update to Fedora/CentOS-Stream/AlmaLinux, & Rocky Linux

### DIFF
--- a/appliances/almalinux.gns3a
+++ b/appliances/almalinux.gns3a
@@ -26,6 +26,30 @@
     },
     "images": [
         {
+            "filename": "AlmaLinux-10-GenericCloud-10.0-20250528.0.x86_64.qcow2",
+            "version": "10.0",
+            "md5sum": "e5099e33f16014b6cc851482d865720d",
+            "filesize": 460062720,
+            "download_url": "https://vault.almalinux.org/10.0/cloud/x86_64/images/",
+            "direct_download_url": "https://vault.almalinux.org/10.0/cloud/x86_64/images/AlmaLinux-10-GenericCloud-10.0-20250528.0.x86_64.qcow2"
+        },
+        {
+            "filename": "AlmaLinux-9-GenericCloud-9.6-20250522.x86_64.qcow2",
+            "version": "9.6",
+            "md5sum": "ae02074389961caf08bbe44439603061",
+            "filesize": 530776064,
+            "download_url": "https://vault.almalinux.org/9.6/cloud/x86_64/images/",
+            "direct_download_url": "https://vault.almalinux.org/9.6/cloud/x86_64/images/AlmaLinux-9-GenericCloud-9.6-20250522.x86_64.qcow2"
+        },
+        {
+            "filename": "AlmaLinux-9-GenericCloud-9.5-20241120.x86_64.qcow2",
+            "version": "9.5",
+            "md5sum": "cb48bc1c609a1d3d62f48397acdd038e",
+            "filesize": 490995712,
+            "download_url": "https://vault.almalinux.org/9.5/cloud/x86_64/images/",
+            "direct_download_url": "https://vault.almalinux.org/9.5/cloud/x86_64/images/AlmaLinux-9-GenericCloud-9.5-20241120.x86_64"
+        },
+        {
             "filename": "AlmaLinux-9-GenericCloud-9.4-20240805.x86_64.qcow2",
             "version": "9.4",
             "md5sum": "7c5040c044a989c524d40824cebb4a4d",
@@ -75,6 +99,27 @@
         }
     ],
     "versions": [
+        {
+            "name": "10.0",
+            "images": {
+                "hda_disk_image": "AlmaLinux-10-GenericCloud-10.0-20250528.0.x86_64.qcow2",
+                "cdrom_image": "almalinux-cloud-init-data.iso"
+            }
+        },
+        {
+            "name": "9.6",
+            "images": {
+                "hda_disk_image": "AlmaLinux-9-GenericCloud-9.6-20250522.x86_64.qcow2",
+                "cdrom_image": "almalinux-cloud-init-data.iso"
+            }
+        },
+        {
+            "name": "9.5",
+            "images": {
+                "hda_disk_image": "AlmaLinux-9-GenericCloud-9.5-20241120.x86_64.qcow2",
+                "cdrom_image": "almalinux-cloud-init-data.iso"
+            }
+        },
         {
             "name": "9.4",
             "images": {

--- a/appliances/centos-cloud.gns3a
+++ b/appliances/centos-cloud.gns3a
@@ -27,20 +27,20 @@
     },
     "images": [
         {
-            "filename": "CentOS-Stream-GenericCloud-x86_64-10-20250331.0.x86_64.qcow2",
-            "version": "Stream-10 (20250331.0)",
-            "md5sum": "776033371ca346001dd6390f0cbaf0d0",
-            "filesize": 952041472,
+            "filename": "CentOS-Stream-GenericCloud-10-20260504.0.x86_64.qcow2",
+            "version": "Stream-10 (20260504.0)",
+            "md5sum": "932b0bcc7e5c7404f91432979dc95314",
+            "filesize": 2173501440,
             "download_url": "https://cloud.centos.org/centos/10-stream/x86_64/images",
-            "direct_download_url": "https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-x86_64-10-20250331.0.x86_64.qcow2"
+            "direct_download_url": "https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-10-20260504.0.x86_64.qcow2"
         },
         {
-            "filename": "CentOS-Stream-GenericCloud-9-20250331.0.x86_64.qcow2",
-            "version": "Stream-9 (20250331.0)",
-            "md5sum": "4aaeddc6ca497065522c75a7471f9bfd",
-            "filesize": 1250625536,
+            "filename": "CentOS-Stream-GenericCloud-9-20260504.0.x86_64.qcow2",
+            "version": "Stream-9 (20260504.0)",
+            "md5sum": "ebfbbd23ba7b85bbaf83c6c0626c2b70",
+            "filesize": 1877251072,
             "download_url": "https://cloud.centos.org/centos/9-stream/x86_64/images",
-            "direct_download_url": "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20250331.0.x86_64.qcow2"
+            "direct_download_url": "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20260504.0.x86_64.qcow2"
         },
         {
             "filename": "CentOS-Stream-GenericCloud-8-20240603.0.x86_64.qcow2",
@@ -61,16 +61,16 @@
     ],
     "versions": [
         {
-            "name": "Stream-10 (20250331.0)",
+            "name": "Stream-10 (20260504.0)",
             "images": {
-                "hda_disk_image": "CentOS-Stream-GenericCloud-x86_64-10-20250331.0.x86_64.qcow2",
+                "hda_disk_image": "CentOS-Stream-GenericCloud-10-20260504.0.x86_64.qcow2",
                 "cdrom_image": "centos-cloud-init-data.iso"
             }
         },
         {
-            "name": "Stream-9 (20250331.0)",
+            "name": "Stream-9 (20260504.0)",
             "images": {
-                "hda_disk_image": "CentOS-Stream-GenericCloud-9-20250331.0.x86_64.qcow2",
+                "hda_disk_image": "CentOS-Stream-GenericCloud-9-20260504.0.x86_64.qcow2",
                 "cdrom_image": "centos-cloud-init-data.iso"
             }
         },

--- a/appliances/fedora-cloud.gns3a
+++ b/appliances/fedora-cloud.gns3a
@@ -27,36 +27,36 @@
     },
     "images": [
         {
+            "filename": "Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2",
+            "version": "44-1.7",
+            "md5sum": "49784011eb752291bfead24d3be8163f",
+            "filesize": 583729152,
+            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images",
+            "direct_download_url": "https://fedora.mirrorservice.org/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
+        },
+        {
+            "filename": "Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2",
+            "version": "43-1.6",
+            "md5sum": "f2f671db53fae58b79bb2e2259fa3622",
+            "filesize": 583335936,
+            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images",
+            "direct_download_url": "https://fedora.mirrorservice.org/fedora/linux/releases/43/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2"
+        },
+        {
+            "filename": "Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2",
+            "version": "42-1.1",
+            "md5sum": "2d660d2adc20b1fe793df5cb66f1d868",
+            "filesize": 532217856,
+            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images",
+            "direct_download_url": "https://fedora.mirrorservice.org/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2"
+        },
+        {
             "filename": "Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2",
             "version": "41-1.4",
             "md5sum": "8efc9edc04f38775de72ce067166b2a1",
             "filesize": 491716608,
             "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images",
             "direct_download_url": "https://fedora.mirrorservice.org/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2"
-        },
-        {
-            "filename": "Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2",
-            "version": "40-1.14",
-            "md5sum": "3eed4b1a9de35208ed30d9bb72c1522d",
-            "filesize": 397475840,
-            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images",
-            "direct_download_url": "https://fedora.mirrorservice.org/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2"
-        },
-        {
-            "filename": "Fedora-Cloud-Base-39-1.5.x86_64.qcow2",
-            "version": "39-1.5",
-            "md5sum": "800a10df2d369891ed65900bcacacd47",
-            "filesize": 544604160,
-            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images",
-            "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2"
-        },
-        {
-            "filename": "Fedora-Cloud-Base-38-1.6.x86_64.qcow2",
-            "version": "38-1.6",
-            "md5sum": "53ddfe7b28666d5ddc55e93ff06abad2",
-            "filesize": 497287168,
-            "download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images",
-            "direct_download_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
         },
         {
             "filename": "fedora-cloud-init-data.iso",
@@ -69,30 +69,30 @@
     ],
     "versions": [
         {
+            "name": "44-1.7",
+            "images": {
+                "hda_disk_image": "Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2",
+                "cdrom_image": "fedora-cloud-init-data.iso"
+            }
+        },
+        {
+            "name": "43-1.6",
+            "images": {
+                "hda_disk_image": "Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2",
+                "cdrom_image": "fedora-cloud-init-data.iso"
+            }
+        },
+        {
+            "name": "42-1.1",
+            "images": {
+                "hda_disk_image": "Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2",
+                "cdrom_image": "fedora-cloud-init-data.iso"
+            }
+        },
+        {
             "name": "41-1.4",
             "images": {
                 "hda_disk_image": "Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2",
-                "cdrom_image": "fedora-cloud-init-data.iso"
-            }
-        },
-        {
-            "name": "40-1.14",
-            "images": {
-                "hda_disk_image": "Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2",
-                "cdrom_image": "fedora-cloud-init-data.iso"
-            }
-        },
-        {
-            "name": "39-1.5",
-            "images": {
-                "hda_disk_image": "Fedora-Cloud-Base-39-1.5.x86_64.qcow2",
-                "cdrom_image": "fedora-cloud-init-data.iso"
-            }
-        },
-        {
-            "name": "38-1.6",
-            "images": {
-                "hda_disk_image": "Fedora-Cloud-Base-38-1.6.x86_64.qcow2",
                 "cdrom_image": "fedora-cloud-init-data.iso"
             }
         }

--- a/appliances/rockylinux.gns3a
+++ b/appliances/rockylinux.gns3a
@@ -17,7 +17,7 @@
     "qemu": {
         "adapter_type": "virtio-net-pci",
         "adapters": 1,
-        "ram": 1024,
+        "ram": 1536,
         "hda_disk_interface": "virtio",
         "arch": "x86_64",
         "console_type": "telnet",
@@ -26,6 +26,22 @@
         "options": "-nographic -cpu host"
     },
     "images": [
+        {
+            "filename": "Rocky-10-GenericCloud-Base-10.1-20251116.0.x86_64.qcow2",
+            "version": "10.1",
+            "md5sum": "729d7235716bd41a0a15e07d2b44c679",
+            "filesize": 575406080,
+            "download_url": "https://download.rockylinux.org/pub/rocky/9/images/x86_64/",
+            "direct_download_url": "https://download.rockylinux.org/pub/rocky/10/images/x86_64/Rocky-10-GenericCloud-Base-10.1-20251116.0.x86_64.qcow2"
+        },
+        {
+            "filename": "Rocky-9-GenericCloud-Base-9.7-20251123.2.x86_64.qcow2",
+            "version": "9.7",
+            "md5sum": "4a0cbfb45b97f09b690044429aaca1c8",
+            "filesize": 648806400,
+            "download_url": "https://download.rockylinux.org/pub/rocky/9/images/x86_64/",
+            "direct_download_url": "https://download.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base-9.7-20251123.2.x86_64.qcow2"
+        },
         {
             "filename": "Rocky-9-GenericCloud-Base-9.5-20241118.0.x86_64.qcow2",
             "version": "9.5",
@@ -76,6 +92,20 @@
         }
     ],
     "versions": [
+        {
+            "name": "10.1",
+            "images": {
+                "hda_disk_image": "Rocky-10-GenericCloud-Base-10.1-20251116.0.x86_64.qcow2",
+                "cdrom_image": "rocky-cloud-init-data.iso"
+            }
+        },
+        {
+            "name": "9.7",
+            "images": {
+                "hda_disk_image": "Rocky-9-GenericCloud-Base-9.7-20251123.2.x86_64.qcow2",
+                "cdrom_image": "rocky-cloud-init-data.iso"
+            }
+        },
         {
             "name": "9.5",
             "images": {


### PR DESCRIPTION

Fedora-Cloud: 41 / 42 / 43 / 44
CentOS-Stream: 9 / 10
Alma Linux: 9.5 / 9.6 / 10.0
RockyLinux: 9.7 / 10.1

`python ./check.py` passes on all 4 of the edited files
Fedora 44 & CentOS-Stream 10.1 Both boots fine and are able to login without issue

---
When updating an **existing** appliance:
- [X ] The new version is on top.
- [ X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [ X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
