### PR TITLE
Updating Oracle Linux Cloud Guest images

### DIFF
--- a/appliances/oracle-linux-cloud.gns3a
+++ b/appliances/oracle-linux-cloud.gns3a
@@ -17,7 +17,7 @@
     "qemu": {
         "adapter_type": "virtio-net-pci",
         "adapters": 1,
-        "ram": 1024,
+        "ram": 1536,
         "hda_disk_interface": "virtio",
         "arch": "x86_64",
         "console_type": "telnet",
@@ -27,60 +27,36 @@
     },
     "images": [
         {
-            "filename": "OL9U5_x86_64-kvm-b259.qcow2",
-            "version": "9.5",
-            "md5sum": "05e9b62c408ab49a02d6833fc683d1ad",
-            "filesize": 652935168,
+            "filename": "OL10U1_x86_64-kvm-b270.qcow2",
+            "version": "10.1",
+            "md5sum": "c3ed48965110e0cbbd75734d3c23a2ce",
+            "filesize": 1044119552,
             "download_url": "https://yum.oracle.com/oracle-linux-templates.html",
-            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL9/u5/x86_64/OL9U5_x86_64-kvm-b259.qcow2"
+            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL10/u1/x86_64/OL10U1_x86_64-kvm-b270.qcow2"
         },
         {
-            "filename": "OL9U2_x86_64-kvm-b197.qcow",
-            "version": "9.2",
-            "md5sum": "2ff3d0bc8a243ad89c96215f303f1c73",
-            "filesize": 560791552,
+            "filename": "OL9U7_x86_64-kvm-b269.qcow2",
+            "version": "9.7",
+            "md5sum": "fe0c555620d2001bb4d4d95a53b43738",
+            "filesize": 792985600,
             "download_url": "https://yum.oracle.com/oracle-linux-templates.html",
-            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL9/u2/x86_64/OL9U2_x86_64-kvm-b197.qcow"
+            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL9/u7/x86_64/OL9U7_x86_64-kvm-b269.qcow2"
         },
         {
-            "filename": "OL9U1_x86_64-kvm-b158.qcow",
-            "version": "9.1",
-            "md5sum": "9f32851b96fc38191892197fa11f7435",
-            "filesize": 539033600,
-            "download_url": "https://yum.oracle.com/oracle-linux-templates.html",
-            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL9/u1/x86_64/OL9U1_x86_64-kvm-b158.qcow"
-        },
-        {
-            "filename": "OL8U10_x86_64-kvm-b258.qcow2",
+            "filename": "OL8U10_x86_64-kvm-b271.qcow2",
             "version": "8.10",
-            "md5sum": "bb07581af5122515b6822595ded5deef",
-            "filesize": 1251672064,
+            "md5sum": "f3184e536af1c2aba6b6f499b1a7085a",
+            "filesize": 1585643520,
             "download_url": "https://yum.oracle.com/oracle-linux-templates.html",
-            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL8/u10/x86_64/OL8U10_x86_64-kvm-b258.qcow2"
+            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL8/u10/x86_64/OL8U10_x86_64-kvm-b271.qcow2"
         },
         {
-            "filename": "OL8U8_x86_64-kvm-b198.qcow",
-            "version": "8.8",
-            "md5sum": "717622f373d77349cc102a3a325efbd3",
-            "filesize": 934215680,
-            "download_url": "https://yum.oracle.com/oracle-linux-templates.html",
-            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL8/u8/x86_64/OL8U8_x86_64-kvm-b198.qcow"
-        },
-        {
-            "filename": "OL8U7_x86_64-kvm-b148.qcow",
-            "version": "8.7",
-            "md5sum": "962cdde7e810888b9914e937222f687f",
-            "filesize": 913965056,
-            "download_url": "https://yum.oracle.com/oracle-linux-templates.html",
-            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL8/u7/x86_64/OL8U7_x86_64-kvm-b148.qcow"
-        },
-        {
-            "filename": "OL7U9_x86_64-kvm-b145.qcow",
+            "filename": "OL7U9_x86_64-kvm-b257.qcow2",
             "version": "7.9",
-            "md5sum": "e60d4145a69b34026db6121109ca9131",
-            "filesize": 725221376,
+            "md5sum": "d3af7cf0b8f44d298a67ce9ebe184494",
+            "filesize": 998244352,
             "download_url": "https://yum.oracle.com/oracle-linux-templates.html",
-            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL7/u9/x86_64/OL7U9_x86_64-kvm-b145.qcow"
+            "direct_download_url": "https://yum.oracle.com/templates/OracleLinux/OL7/u9/x86_64/OL7U9_x86_64-kvm-b257.qcow2"
         },
         {
             "filename": "oracle-cloud-init-data.iso",
@@ -93,51 +69,30 @@
     ],
     "versions": [
         {
-            "name": "9.5",
+            "name": "10.1",
             "images": {
-                "hda_disk_image": "OL9U5_x86_64-kvm-b259.qcow2",
+                "hda_disk_image": "OL10U1_x86_64-kvm-b270.qcow2",
                 "cdrom_image": "oracle-cloud-init-data.iso"
             }
         },
         {
-            "name": "9.2",
+            "name": "9.7",
             "images": {
-                "hda_disk_image": "OL9U2_x86_64-kvm-b197.qcow",
-                "cdrom_image": "oracle-cloud-init-data.iso"
-            }
-        },
-        {
-            "name": "9.1",
-            "images": {
-                "hda_disk_image": "OL9U1_x86_64-kvm-b158.qcow",
+                "hda_disk_image": "OL9U7_x86_64-kvm-b269.qcow2",
                 "cdrom_image": "oracle-cloud-init-data.iso"
             }
         },
         {
             "name": "8.10",
             "images": {
-                "hda_disk_image": "OL8U10_x86_64-kvm-b258.qcow2",
-                "cdrom_image": "oracle-cloud-init-data.iso"
-            }
-        },
-        {
-            "name": "8.8",
-            "images": {
-                "hda_disk_image": "OL8U8_x86_64-kvm-b198.qcow",
-                "cdrom_image": "oracle-cloud-init-data.iso"
-            }
-        },
-        {
-            "name": "8.7",
-            "images": {
-                "hda_disk_image": "OL8U7_x86_64-kvm-b148.qcow",
+                "hda_disk_image": "OL8U10_x86_64-kvm-b271.qcow2",
                 "cdrom_image": "oracle-cloud-init-data.iso"
             }
         },
         {
             "name": "7.9",
             "images": {
-                "hda_disk_image": "OL7U9_x86_64-kvm-b145.qcow",
+                "hda_disk_image": "OL7U9_x86_64-kvm-b257.qcow2",
                 "cdrom_image": "oracle-cloud-init-data.iso"
             }
         }


### PR DESCRIPTION

Updating the Oracle Linux Cloud Images to reflect only the images available from
https://yum.oracle.com/oracle-linux-templates.html as of 2026-05-05

`python ./check.py` passes with the changed file and 10.1 also boots fine in my Local GNS3

---
When updating an **existing** appliance:
- [X] The new version is on top.
- [X] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [X] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
