### PR TITLE
Add iol version 17.18.02

### DIFF
--- a/appliances/cisco-iou-l2.gns3a
+++ b/appliances/cisco-iou-l2.gns3a
@@ -22,6 +22,12 @@
     },
     "images": [
         {
+            "filename": "x86_64_crb_linux_l2-adventerprisek9-ms.17.18.2.iol",
+            "version": "17.18.2",
+            "md5sum": "0e460cbcfa9e0b76ca400162928fd989",
+            "filesize": 246471208
+        },
+        {
             "filename": "x86_64_crb_linux_l2-adventerprisek9-ms.17.16.1a.iol",
             "version": "17.16.1a",
             "md5sum": "d55879318e51c5401fb9314d45c67728",
@@ -41,6 +47,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "17.18.2",
+            "images": {
+                "image": "x86_64_crb_linux_l2-adventerprisek9-ms.17.18.2.iol"
+            }
+        },
         {
             "name": "17.16.1a",
             "images": {

--- a/appliances/cisco-iou-l3.gns3a
+++ b/appliances/cisco-iou-l3.gns3a
@@ -22,6 +22,12 @@
     },
     "images": [
         {
+            "filename": "x86_64_crb_linux-adventerprisek9-ms.17.18.2.iol",
+            "version": "17.18.2",
+            "md5sum": "34bf876c5b3c60f3ef4eb28eb8a176d7",
+            "filesize": 293729288
+        },
+        {
             "filename": "x86_64_crb_linux-adventerprisek9-ms.17.16.1a.iol",
             "version": "17.16.1a",
             "md5sum": "39bdf959c3b99a3c81d66451f1cf0404",
@@ -41,6 +47,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "17.18.2",
+            "images": {
+                "image": "x86_64_crb_linux-adventerprisek9-ms.17.18.2.iol"
+            }
+        },
         {
             "name": "17.16.1a",
             "images": {


### PR DESCRIPTION
I have updated appliance defintion for cisco-iou-l2 and cisco-iou-l3 to include IOL version 17.18.2

python check.py
=> Check appliances
Check 6wind-turbo-router.gns3a
Check a10-vthunder.gns3a
Check aaa.gns3a
Check alcatel-7750.gns3a
Check almalinux.gns3a
Check alpine-cloud.gns3a
Check alpine-linux-virt.gns3a
Check alpine-linux.gns3a
Check alpinet.gns3a
Check arista-ceos.gns3a
Check arista-veos.gns3a
Check armbian.gns3a
Appliance armbian.gns3a does not validate against schema version 4: Additional properties are not allowed ('uefi' was unexpected)