### PR TITLE
Update Asterfusion AsterNOS-VPP to V6.1_R0104P02

### DIFF
--- a/appliances/asterfusion-vAsterNOS-VPP.gns3a
+++ b/appliances/asterfusion-vAsterNOS-VPP.gns3a
@@ -14,8 +14,16 @@
     "availability": "with-registration",
     "images": [
         {
+            "filename": "AsterNOS-VPP_V6.1-R0104P02_x86.img",
+            "version": "6.1_R0104P02",
+            "md5sum": "a02926586176559b9ead106baa934ce0",
+            "filesize": 2584018944,
+            "download_url": "https://asternos.dev/api/file/db840750-01fd-4d1f-9e35-efa3ce30193f",
+            "compression": "gzip"
+        },
+        {
             "filename": "AsterNOS-VPP_V6.1-R0101P02_x86.img",
-            "version": "6.1",
+            "version": "6.1_R0101P02",
             "md5sum": "55834c3e8849ab226144d79ef76acf81",
             "filesize": 1318201015,
             "download_url": "https://asternos.dev/api/file/b2c9fd83-a9d3-46f3-9676-6b49dd481d6c",
@@ -33,7 +41,13 @@
     },
     "versions": [
         {
-            "name": "6.1",
+            "name": "6.1_R0104P02",
+            "images": {
+                "hda_disk_image": "AsterNOS-VPP_V6.1-R0104P02_x86.img"
+            }
+        },
+        {
+            "name": "6.1_R0101P02",
             "images": {
                 "hda_disk_image": "AsterNOS-VPP_V6.1-R0101P02_x86.img"
             }


### PR DESCRIPTION
This PR updates the Asterfusion AsterNOS-VPP appliance.

Changes:
- Add AsterNOS-VPP V6.1_R0104P02
- Keep the previous V6.1_R0101P02 image available
- Add the new image download URL, MD5 checksum, and file size
- Keep the existing QEMU appliance settings unchanged

The version naming now follows the official AsterNOS-VPP release naming used on the AsterNOS website.