### PR TITLE
Add FreeBSD 15.0 and update 14.0 download link

### DIFF
--- a/appliances/freebsd.gns3a
+++ b/appliances/freebsd.gns3a
@@ -25,12 +25,21 @@
     },
     "images": [
         {
+            "filename": "FreeBSD-15.0-RELEASE-amd64-zfs.qcow2",
+	        "version": "15.0-zfs",
+	        "md5sum": "d3109107e34336081eb88665674cbca4",
+	        "filesize": 2854944768,
+	        "download_url": "https://www.freebsd.org/where.html",
+	        "direct_download_url": "https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/FreeBSD-15.0-RELEASE-amd64-ufs.qcow2.xz",
+	        "compression": "xz"
+        },
+        {
             "filename": "FreeBSD-14.0-RELEASE-amd64.qcow2",
             "version": "14.0",
             "md5sum": "87b988eaa4a8aaabea1c10649c98b3f0",
             "filesize": 3506569216,
             "download_url": "https://www.freebsd.org/where.html",
-            "direct_download_url": "https://download.freebsd.org/releases/VM-IMAGES/14.0-RELEASE/amd64/Latest/FreeBSD-14.0-RELEASE-amd64.qcow2.xz",
+            "direct_download_url": "https://archive.freebsd.org/old-releases/VM-IMAGES/14.0-RELEASE/amd64/Latest/FreeBSD-14.0-RELEASE-amd64.qcow2.xz",
             "compression": "xz"
         },
         {
@@ -53,6 +62,12 @@
         }
     ],
     "versions": [
+        {
+            "name": "15.0-zfs",
+            "images": {
+                "hda_disk_image": "FreeBSD-15.0-RELEASE-amd64-zfs.qcow2"
+            }
+        },
         {
             "name": "14.0",
             "images": {


### PR DESCRIPTION
This commint adds FreeBSD 15.0-RELEASE-amd64-zfs appliance and updates the FreeBSD 14.0 image download link to prevent 404 error.

Before submitting a pull request, please check the following.

---
When updating an **existing** appliance:
- [x] The new version is on top.
- [x] The filenames in the "images" section are unique, to avoid appliances / version overwriting each other.
- [x] If you forked the repo, running check.py doesn't drop any errors for the updated file.
---
When creating a **new** appliance:
- It's tested locally, i.e.
  - [x] You dragged an instance into a project on your box, got it installed (if necessary), and did some basic network checks (ping, UI reachable, etc.).
  - [ ] GNS3 VM can run it without any tweaks.
  - [ ] The device is in the right category: router, switch, guest (hosts), firewall
  - [ ] You filled in as much info as possible (checks the schemas and other appliance files for some guidance).
- [ ] When adding a container: it builds on Docker Hub and can be pulled.
- [ ] The filenames in the "images" section are unique (to avoid appliances and/or versions overwriting each other).
- [x] If you forked the repo, running check.py doesn't drop any errors for the new file.
- [ ] *Optional: a symbol has been created for the new appliance.*
